### PR TITLE
Adding support for Python 3.

### DIFF
--- a/pypower/_compat.py
+++ b/pypower/_compat.py
@@ -1,0 +1,9 @@
+
+"""
+Compatibility helpers for older Python versions.
+
+"""
+import sys
+
+
+PY2 = sys.version_info[0] == 2

--- a/pypower/add_userfcn.py
+++ b/pypower/add_userfcn.py
@@ -110,7 +110,7 @@ def add_userfcn(ppc, stage, fcn, args=None, allow_multiple=False):
             if not allow_multiple:
                 for k in range(n):
                     if ppc['userfcn'][stage][k]['fcn'] == fcn:
-                        stderr.write('add_userfcn: the function \'%s\' has already been added\n' % fcn.func_name)
+                        stderr.write('add_userfcn: the function \'%s\' has already been added\n' % fcn.__name__)
         else:
             ppc['userfcn'][stage] = []
     else:

--- a/pypower/bustypes.py
+++ b/pypower/bustypes.py
@@ -20,8 +20,8 @@
 from numpy import ones, flatnonzero as find
 from scipy.sparse import csr_matrix as sparse
 
-from idx_bus import BUS_TYPE, REF, PV, PQ
-from idx_gen import GEN_BUS, GEN_STATUS
+from pypower.idx_bus import BUS_TYPE, REF, PV, PQ
+from pypower.idx_gen import GEN_BUS, GEN_STATUS
 
 def bustypes(bus, gen):
     """Builds index lists of each type of bus (C{REF}, C{PV}, C{PQ}).

--- a/pypower/cplex_options.py
+++ b/pypower/cplex_options.py
@@ -16,14 +16,18 @@
 
 """Sets options for CPLEX.
 """
-
 try:
     from cplex import cplexoptimset
 except ImportError:
 #    print "CPLEX not available"
     pass
 
+from pypower._compat import PY2
 from pypower.util import feval
+
+
+if not PY2:
+    basestring = str
 
 
 def cplex_options(overrides=None, ppopt=None):

--- a/pypower/d2AIbr_dV2.py
+++ b/pypower/d2AIbr_dV2.py
@@ -19,7 +19,7 @@
 
 from scipy.sparse import csr_matrix as sparse
 
-from d2Ibr_dV2 import d2Ibr_dV2
+from pypower.d2Ibr_dV2 import d2Ibr_dV2
 
 
 def d2AIbr_dV2(dIbr_dVa, dIbr_dVm, Ibr, Ybr, V, lam):

--- a/pypower/d2ASbr_dV2.py
+++ b/pypower/d2ASbr_dV2.py
@@ -19,7 +19,7 @@
 
 from scipy.sparse import csr_matrix
 
-from d2Sbr_dV2 import d2Sbr_dV2
+from pypower.d2Sbr_dV2 import d2Sbr_dV2
 
 
 def d2ASbr_dV2(dSbr_dVa, dSbr_dVm, Sbr, Cbr, Ybr, V, lam):

--- a/pypower/dSbr_dV.py
+++ b/pypower/dSbr_dV.py
@@ -20,7 +20,7 @@
 from numpy import conj, arange, diag, zeros, asmatrix, asarray, asscalar
 from scipy.sparse import issparse, csr_matrix as sparse
 
-from idx_brch import F_BUS, T_BUS
+from pypower.idx_brch import F_BUS, T_BUS
 
 def dSbr_dV(branch, Yf, Yt, V):
     """Computes partial derivatives of power flows w.r.t. voltage.

--- a/pypower/dcopf.py
+++ b/pypower/dcopf.py
@@ -17,9 +17,9 @@
 """Solves a DC optimal power flow.
 """
 
-from opf_args import opf_args2
-from ppoption import ppoption
-from opf import opf
+from pypower.opf_args import opf_args2
+from pypower.ppoption import ppoption
+from pypower.opf import opf
 
 
 def dcopf(*args, **kw_args):

--- a/pypower/dcopf_solver.py
+++ b/pypower/dcopf_solver.py
@@ -28,10 +28,10 @@ from numpy import flatnonzero as find
 
 from scipy.sparse import vstack, hstack, csr_matrix as sparse
 
-from idx_bus import BUS_TYPE, REF, VA, LAM_P, LAM_Q, MU_VMAX, MU_VMIN
-from idx_gen import PG, MU_PMAX, MU_PMIN, MU_QMAX, MU_QMIN
-from idx_brch import PF, PT, QF, QT, RATE_A, MU_SF, MU_ST
-from idx_cost import MODEL, POLYNOMIAL, PW_LINEAR, NCOST, COST
+from pypower.idx_bus import BUS_TYPE, REF, VA, LAM_P, LAM_Q, MU_VMAX, MU_VMIN
+from pypower.idx_gen import PG, MU_PMAX, MU_PMIN, MU_QMAX, MU_QMIN
+from pypower.idx_brch import PF, PT, QF, QT, RATE_A, MU_SF, MU_ST
+from pypower.idx_cost import MODEL, POLYNOMIAL, PW_LINEAR, NCOST, COST
 
 from pypower.util import sub2ind
 from pypower.ipopt_options import ipopt_options
@@ -222,7 +222,7 @@ def dcopf_solver(om, ppopt, out_opt=None):
     elif alg == 600:
         opt['mosek_opt'] = mosek_options([], ppopt)
     else:
-        raise ValueError, "Unrecognised solver [%d]." % alg
+        raise ValueError("Unrecognised solver [%d]." % alg)
 
     ##-----  run opf  -----
     x, f, info, output, lmbda = \

--- a/pypower/ext2int.py
+++ b/pypower/ext2int.py
@@ -26,13 +26,13 @@ from numpy import flatnonzero as find
 
 from scipy.sparse import issparse, vstack, hstack, csr_matrix as sparse
 
-from idx_bus import PQ, PV, REF, NONE, BUS_I, BUS_TYPE
-from idx_gen import GEN_BUS, GEN_STATUS
-from idx_brch import F_BUS, T_BUS, BR_STATUS
-from idx_area import PRICE_REF_BUS
+from pypower.idx_bus import PQ, PV, REF, NONE, BUS_I, BUS_TYPE
+from pypower.idx_gen import GEN_BUS, GEN_STATUS
+from pypower.idx_brch import F_BUS, T_BUS, BR_STATUS
+from pypower.idx_area import PRICE_REF_BUS
 
-from get_reorder import get_reorder
-from run_userfcn import run_userfcn
+from pypower.get_reorder import get_reorder
+from pypower.run_userfcn import run_userfcn
 
 
 def ext2int(ppc, val_or_field=None, ordering=None, dim=0):
@@ -248,8 +248,8 @@ def ext2int(ppc, val_or_field=None, ordering=None, dim=0):
                         v_ext[fld] = {}
                         v_ext = v_ext[fld]
 
-            exec 'ppc["order"]["ext"]%s = ppc%s.copy()' % (key, key)
-            exec 'ppc%s = ext2int(ppc, ppc%s, ordering, dim)' % (key, key)
+            exec('ppc["order"]["ext"]%s = ppc%s.copy()' % (key, key))
+            exec('ppc%s = ext2int(ppc, ppc%s, ordering, dim)' % (key, key))
 
         else:
             ## value
@@ -281,7 +281,7 @@ def ext2int(ppc, val_or_field=None, ordering=None, dim=0):
                     elif dim == 1:
                         hstack(new_v, 'csr')
                     else:
-                        raise ValueError, 'dim (%d) may be 0 or 1' % dim
+                        raise ValueError('dim (%d) may be 0 or 1' % dim)
                 else:
                     val = concatenate(new_v, dim)
             return val

--- a/pypower/fdpf.py
+++ b/pypower/fdpf.py
@@ -22,7 +22,7 @@ import sys
 from numpy import array, angle, exp, linalg, conj, r_, Inf
 from scipy.sparse.linalg import splu
 
-from ppoption import ppoption
+from pypower.ppoption import ppoption
 
 
 def fdpf(Ybus, Sbus, V0, Bp, Bpp, ref, pv, pq, ppopt=None):

--- a/pypower/gausspf.py
+++ b/pypower/gausspf.py
@@ -21,7 +21,7 @@ import sys
 
 from numpy import linalg, conj, r_, Inf, asscalar
 
-from ppoption import ppoption
+from pypower.ppoption import ppoption
 
 
 def gausspf(Ybus, Sbus, V0, ref, pv, pq, ppopt=None):

--- a/pypower/get_reorder.py
+++ b/pypower/get_reorder.py
@@ -36,8 +36,8 @@ def get_reorder(A, idx, dim=0):
         elif dim == 1:
             B = A[:, idx].copy()
         else:
-            raise ValueError, 'dim (%d) may be 0 or 1' % dim
+            raise ValueError('dim (%d) may be 0 or 1' % dim)
     else:
-        raise ValueError, 'number of dimensions (%d) may be 1 or 2' % dim
+        raise ValueError('number of dimensions (%d) may be 1 or 2' % dim)
 
     return B

--- a/pypower/hasPQcap.py
+++ b/pypower/hasPQcap.py
@@ -21,7 +21,7 @@ from sys import stderr
 
 from numpy import any, zeros, nonzero
 
-from idx_gen import QMAX, QMIN, PMAX, PC1, PC2, QC1MIN, QC1MAX, QC2MIN, QC2MAX
+from pypower.idx_gen import QMAX, QMIN, PMAX, PC1, PC2, QC1MIN, QC1MAX, QC2MIN, QC2MAX
 
 
 def hasPQcap(gen, hilo='B'):

--- a/pypower/int2ext.py
+++ b/pypower/int2ext.py
@@ -23,10 +23,10 @@ from copy import deepcopy
 
 from numpy import arange, concatenate
 
-from idx_bus import BUS_I
-from idx_gen import GEN_BUS
-from idx_brch import F_BUS, T_BUS
-from idx_area import PRICE_REF_BUS
+from pypower.idx_bus import BUS_I
+from pypower.idx_gen import GEN_BUS
+from pypower.idx_brch import F_BUS, T_BUS
+from pypower.idx_area import PRICE_REF_BUS
 
 from pypower.get_reorder import get_reorder
 from pypower.set_reorder import set_reorder
@@ -177,8 +177,8 @@ def int2ext(ppc, val_or_field=None, oldval=None, ordering=None, dim=0):
                         v_int[fld] = {}
                         v_int = v_int[fld]
 
-            exec 'ppc["order"]["int"]%s = ppc%s.copy()' % (key, key)
-            exec 'ppc%s = int2ext(ppc, ppc%s, ppc["order"]["ext"]%s, ordering, dim)' % (key, key, key)
+            exec('ppc["order"]["int"]%s = ppc%s.copy()' % (key, key))
+            exec('ppc%s = int2ext(ppc, ppc%s, ppc["order"]["ext"]%s, ordering, dim)' % (key, key, key))
 
         else:
             ## value

--- a/pypower/ipopt_options.py
+++ b/pypower/ipopt_options.py
@@ -17,7 +17,12 @@
 """Sets options for IPOPT.
 """
 
+from pypower._compat import PY2
 from pypower.util import feval
+
+
+if not PY2:
+    basestring = str
 
 
 def ipopt_options(overrides=None, ppopt=None):

--- a/pypower/isload.py
+++ b/pypower/isload.py
@@ -17,7 +17,7 @@
 """Checks for dispatchable loads.
 """
 
-from idx_gen import PMAX, PMIN
+from pypower.idx_gen import PMAX, PMIN
 
 
 def isload(gen):

--- a/pypower/loadcase.py
+++ b/pypower/loadcase.py
@@ -27,8 +27,13 @@ from numpy import array, zeros, ones, c_
 
 from scipy.io import loadmat
 
+from pypower._compat import PY2
 from pypower.idx_gen import PMIN, MU_PMAX, MU_PMIN, MU_QMAX, MU_QMIN, APF
 from pypower.idx_brch import PF, QF, PT, QT, MU_SF, MU_ST, BR_STATUS
+
+
+if not PY2:
+    basestring = str
 
 
 def loadcase(casefile,
@@ -100,21 +105,25 @@ def loadcase(casefile,
                         d['version'] = '1'
 
                         s = {}
-                        for k, v in d.iteritems():
+                        for k, v in d.items():
                             s[k] = v
 
                     s['baseMVA'] = s['baseMVA'][0]  # convert array to float
 
-                except IOError, e:
+                except IOError as e:
                     info = 3
                     lasterr = str(e)
             elif extension == '.py':      ## from Python file
                 try:
-                    execfile(rootname + extension)
+                    if PY2:
+                        execfile(rootname + extension)
+                    else:
+                        exec(compile(open(rootname + extension).read(),
+                                     rootname + extension, 'exec'))
 
                     try:                      ## assume it returns an object
                         s = eval(fname)()
-                    except ValueError, e:
+                    except ValueError as e:
                         info = 4
                         lasterr = str(e)
                     ## if not try individual data matrices
@@ -125,7 +134,7 @@ def loadcase(casefile,
                             try:
                                 s['baseMVA'], s['bus'], s['gen'], s['branch'], \
                                 s['areas'], s['gencost'] = eval(fname)()
-                            except IOError, e:
+                            except IOError as e:
                                 info = 4
                                 lasterr = str(e)
                         else:
@@ -134,22 +143,22 @@ def loadcase(casefile,
                                     s['baseMVA'], s['bus'], s['gen'], \
                                         s['branch'], s['areas'], \
                                         s['gencost'] = eval(fname)()
-                                except ValueError, e:
+                                except ValueError as e:
                                     try:
                                         s['baseMVA'], s['bus'], s['gen'], \
                                             s['branch'] = eval(fname)()
-                                    except ValueError, e:
+                                    except ValueError as e:
                                         info = 4
                                         lasterr = str(e)
                             else:
                                 try:
                                     s['baseMVA'], s['bus'], s['gen'], \
                                         s['branch'] = eval(fname)()
-                                except ValueError, e:
+                                except ValueError as e:
                                     info = 4
                                     lasterr = str(e)
 
-                except IOError, e:
+                except IOError as e:
                     info = 4
                     lasterr = str(e)
 

--- a/pypower/main.py
+++ b/pypower/main.py
@@ -103,8 +103,9 @@ containing the case data.""" % usage,
     parser.add_option("-t", "--test", action="store_true", dest="test",
         default=False, help="run tests")
 
-    parser.add_option("-c", "--testcase", default='case9', choices=CASES.keys(),
-        help="built-in test case (choose from: %s)" % str(CASES.keys())[1:-1])
+    parser.add_option("-c", "--testcase", default='case9',
+        choices=list(CASES.keys()),
+        help="built-in test case (choose from: %s)" % str(list(CASES.keys()))[1:-1])
 
     parser.add_option("-o", "--outfile", dest='fname', default='',
         type='string', help="""pretty printed output will be
@@ -164,7 +165,7 @@ heuristic""")
             casedata = CASES[options.testcase]()
         except KeyError:
             stderr.write("Invalid case choice: %r (choose from %s)\n" % \
-                (options.testcase, CASES.keys()))
+                (options.testcase, list(CASES.keys())))
             sys.exit(2)
 
     return options, casedata, ppopt, options.fname, options.solvedcase

--- a/pypower/makeAang.py
+++ b/pypower/makeAang.py
@@ -21,7 +21,7 @@ from numpy import array, ones, zeros, r_, Inf, pi, arange
 from numpy import flatnonzero as find
 from scipy.sparse import csr_matrix as sparse
 
-from idx_brch import F_BUS, T_BUS, ANGMIN, ANGMAX
+from pypower.idx_brch import F_BUS, T_BUS, ANGMIN, ANGMAX
 
 
 def makeAang(baseMVA, branch, nb, ppopt):

--- a/pypower/makeApq.py
+++ b/pypower/makeApq.py
@@ -21,9 +21,9 @@ from numpy import array, linalg, zeros, arange, r_, c_
 from numpy import flatnonzero as find
 from scipy.sparse import csr_matrix as sparse
 
-from idx_gen import PC1, PC2, QC1MIN, QC1MAX, QC2MIN, QC2MAX
+from pypower.idx_gen import PC1, PC2, QC1MIN, QC1MAX, QC2MIN, QC2MAX
 
-from hasPQcap import hasPQcap
+from pypower.hasPQcap import hasPQcap
 
 
 def makeApq(baseMVA, gen):

--- a/pypower/makeAvl.py
+++ b/pypower/makeAvl.py
@@ -23,9 +23,9 @@ from numpy import array, zeros, arange, sin, cos, arctan2, r_
 from numpy import flatnonzero as find
 from scipy.sparse import csr_matrix as sparse
 
-from idx_gen import PG, QG, PMIN, QMIN, QMAX
+from pypower.idx_gen import PG, QG, PMIN, QMIN, QMAX
 
-from isload import isload
+from pypower.isload import isload
 
 
 def makeAvl(baseMVA, gen):

--- a/pypower/makeAy.py
+++ b/pypower/makeAy.py
@@ -21,7 +21,7 @@ from numpy import array, diff, any, zeros, r_, flatnonzero as find
 #from scipy.sparse import csr_matrix as sparse
 from scipy.sparse import lil_matrix as sparse
 
-from idx_cost import MODEL, PW_LINEAR, NCOST, COST
+from pypower.idx_cost import MODEL, PW_LINEAR, NCOST, COST
 
 
 def makeAy(baseMVA, ng, gencost, pgbas, qgbas, ybas):
@@ -79,7 +79,7 @@ def makeAy(baseMVA, ng, gencost, pgbas, qgbas, ybas):
         c = gencost[i, COST + 1:COST + 2 * ns:2]
         m = diff(c) / diff(p)               ## slopes for Pg (or Qg)
         if any(diff(p) == 0):
-            print 'makeAy: bad x axis data in row ##i of gencost matrix' % i
+            print('makeAy: bad x axis data in row ##i of gencost matrix' % i)
         b = m * p[:ns - 1] - c[:ns - 1]        ## and rhs
         by = r_[by,  b]
         if i > ng:

--- a/pypower/makeB.py
+++ b/pypower/makeB.py
@@ -19,10 +19,10 @@
 
 from numpy import ones, zeros, copy
 
-from idx_bus import BS
-from idx_brch import BR_B, BR_R, TAP, SHIFT
+from pypower.idx_bus import BS
+from pypower.idx_brch import BR_B, BR_R, TAP, SHIFT
 
-from makeYbus import makeYbus
+from pypower.makeYbus import makeYbus
 
 
 def makeB(baseMVA, bus, branch, alg):

--- a/pypower/makeBdc.py
+++ b/pypower/makeBdc.py
@@ -22,8 +22,8 @@ from sys import stderr
 from numpy import ones, r_, pi, flatnonzero as find
 from scipy.sparse import csr_matrix as sparse
 
-from idx_bus import BUS_I
-from idx_brch import F_BUS, T_BUS, BR_X, TAP, SHIFT, BR_STATUS
+from pypower.idx_bus import BUS_I
+from pypower.idx_brch import F_BUS, T_BUS, BR_X, TAP, SHIFT, BR_STATUS
 
 
 def makeBdc(baseMVA, bus, branch):
@@ -45,7 +45,7 @@ def makeBdc(baseMVA, bus, branch):
     nl = branch.shape[0]       ## number of lines
 
     ## check that bus numbers are equal to indices to bus (one set of bus nums)
-    if any(bus[:, BUS_I] != range(nb)):
+    if any(bus[:, BUS_I] != list(range(nb))):
         stderr.write('makeBdc: buses must be numbered consecutively in '
                      'bus matrix\n')
 

--- a/pypower/makeLODF.py
+++ b/pypower/makeLODF.py
@@ -20,7 +20,7 @@
 from numpy import ones, diag, eye, r_, arange
 from scipy.sparse import csr_matrix as sparse
 
-from idx_brch import F_BUS, T_BUS
+from pypower.idx_brch import F_BUS, T_BUS
 
 
 def makeLODF(branch, PTDF):

--- a/pypower/makePTDF.py
+++ b/pypower/makePTDF.py
@@ -23,8 +23,8 @@ from numpy import zeros, arange, isscalar, dot, ix_, flatnonzero as find
 
 from numpy.linalg import solve
 
-from idx_bus import BUS_TYPE, REF, BUS_I
-from makeBdc import makeBdc
+from pypower.idx_bus import BUS_TYPE, REF, BUS_I
+from pypower.makeBdc import makeBdc
 
 
 def makePTDF(baseMVA, bus, branch, slack=None):

--- a/pypower/makeSbus.py
+++ b/pypower/makeSbus.py
@@ -20,8 +20,8 @@
 from numpy import ones, flatnonzero as find
 from scipy.sparse import csr_matrix as sparse
 
-from idx_bus import PD, QD
-from idx_gen import GEN_BUS, PG, QG, GEN_STATUS
+from pypower.idx_bus import PD, QD
+from pypower.idx_gen import GEN_BUS, PG, QG, GEN_STATUS
 
 
 def makeSbus(baseMVA, bus, gen):

--- a/pypower/makeYbus.py
+++ b/pypower/makeYbus.py
@@ -22,8 +22,8 @@ from sys import stderr
 from numpy import ones, conj, nonzero, any, exp, pi, r_
 from scipy.sparse import csr_matrix
 
-from idx_bus import BUS_I, GS, BS
-from idx_brch import F_BUS, T_BUS, BR_R, BR_X, BR_B, BR_STATUS, SHIFT, TAP
+from pypower.idx_bus import BUS_I, GS, BS
+from pypower.idx_brch import F_BUS, T_BUS, BR_R, BR_X, BR_B, BR_STATUS, SHIFT, TAP
 
 
 def makeYbus(baseMVA, bus, branch):
@@ -42,7 +42,7 @@ def makeYbus(baseMVA, bus, branch):
     nl = branch.shape[0]       ## number of lines
 
     ## check that bus numbers are equal to indices to bus (one set of bus nums)
-    if any(bus[:, BUS_I] != range(nb)):
+    if any(bus[:, BUS_I] != list(range(nb))):
         stderr.write('buses must appear in order by bus number\n')
 
     ## for each branch, compute the elements of the branch admittance matrix where

--- a/pypower/modcost.py
+++ b/pypower/modcost.py
@@ -21,7 +21,7 @@ import sys
 
 from numpy import zeros, ones, arange, dot, cumsum, flatnonzero as find
 
-from idx_cost import MODEL, NCOST, PW_LINEAR, POLYNOMIAL, COST
+from pypower.idx_cost import MODEL, NCOST, PW_LINEAR, POLYNOMIAL, COST
 
 
 def modcost(gencost, alpha, modtype='SCALE_F'):

--- a/pypower/mosek_options.py
+++ b/pypower/mosek_options.py
@@ -20,7 +20,12 @@ except ImportError:
 #    print "MOSEK not available"
     pass
 
+from pypower._compat import PY2
 from pypower.util import feval
+
+
+if not PY2:
+    basestring = str
 
 
 def mosek_options(overrides=None, ppopt=None):

--- a/pypower/newtonpf.py
+++ b/pypower/newtonpf.py
@@ -24,8 +24,8 @@ from numpy import array, angle, exp, linalg, conj, r_, Inf
 from scipy.sparse import hstack, vstack
 from scipy.sparse.linalg import spsolve
 
-from dSbus_dV import dSbus_dV
-from ppoption import ppoption
+from pypower.dSbus_dV import dSbus_dV
+from pypower.ppoption import ppoption
 
 
 def newtonpf(Ybus, Sbus, V0, ref, pv, pq, ppopt=None):

--- a/pypower/opf.py
+++ b/pypower/opf.py
@@ -29,7 +29,7 @@ from pypower.ext2int import ext2int
 from pypower.opf_args import opf_args2
 from pypower.opf_setup import opf_setup
 from pypower.opf_execute import opf_execute
-from int2ext import int2ext
+from pypower.int2ext import int2ext
 
 
 def opf(*args):

--- a/pypower/opf_args.py
+++ b/pypower/opf_args.py
@@ -22,8 +22,13 @@ from sys import stderr
 from numpy import array
 from scipy.sparse import issparse
 
-from ppoption import ppoption
-from loadcase import loadcase
+from pypower._compat import PY2
+from pypower.ppoption import ppoption
+from pypower.loadcase import loadcase
+
+
+if not PY2:
+    basestring = str
 
 
 def opf_args(*args):

--- a/pypower/opf_consfcn.py
+++ b/pypower/opf_consfcn.py
@@ -21,14 +21,14 @@ from numpy import zeros, ones, conj, exp, r_, Inf, arange
 
 from scipy.sparse import lil_matrix, vstack, hstack, csr_matrix as sparse
 
-from idx_gen import GEN_BUS, PG, QG
-from idx_brch import F_BUS, T_BUS, RATE_A
+from pypower.idx_gen import GEN_BUS, PG, QG
+from pypower.idx_brch import F_BUS, T_BUS, RATE_A
 
-from makeSbus import makeSbus
-from dSbus_dV import dSbus_dV
-from dIbr_dV import dIbr_dV
-from dSbr_dV import dSbr_dV
-from dAbr_dV import dAbr_dV
+from pypower.makeSbus import makeSbus
+from pypower.dSbus_dV import dSbus_dV
+from pypower.dIbr_dV import dIbr_dV
+from pypower.dSbr_dV import dSbr_dV
+from pypower.dAbr_dV import dAbr_dV
 
 
 def opf_consfcn(x, om, Ybus, Yf, Yt, ppopt, il=None, *args):

--- a/pypower/opf_costfcn.py
+++ b/pypower/opf_costfcn.py
@@ -20,10 +20,10 @@
 from numpy import array, ones, zeros, arange, r_, dot, flatnonzero as find
 from scipy.sparse import issparse, csr_matrix as sparse
 
-from idx_cost import MODEL, POLYNOMIAL
+from pypower.idx_cost import MODEL, POLYNOMIAL
 
-from totcost import totcost
-from polycost import polycost
+from pypower.totcost import totcost
+from pypower.polycost import polycost
 
 
 def opf_costfcn(x, om, return_hessian=False):
@@ -135,13 +135,14 @@ def opf_costfcn(x, om, return_hessian=False):
                 ddff[k] = (opf_costfcn(xx, om) - f) / step
             if max(abs(ddff - df)) > tol:
                 idx = find(abs(ddff - df) == max(abs(ddff - df)))
-                print 'Mismatch in gradient'
-                print 'idx             df(num)         df              diff'
-                print '%4d%16g%16g%16g' % \
-                    (range(len(df)), ddff.T, df.T, abs(ddff - df).T)
-                print 'MAX'
-                print '%4d%16g%16g%16g' % \
-                    (idx.T, ddff[idx].T, df[idx].T, abs(ddff[idx] - df[idx]).T)
+                print('Mismatch in gradient')
+                print('idx             df(num)         df              diff')
+                print('%4d%16g%16g%16g' %
+                      (range(len(df)), ddff.T, df.T, abs(ddff - df).T))
+                print('MAX')
+                print('%4d%16g%16g%16g' %
+                      (idx.T, ddff[idx].T, df[idx].T,
+                       abs(ddff[idx] - df[idx]).T))
 
     if not return_hessian:
         return f, df

--- a/pypower/opf_hessfcn.py
+++ b/pypower/opf_hessfcn.py
@@ -20,18 +20,18 @@
 from numpy import array, zeros, ones, exp, arange, r_, flatnonzero as find
 from scipy.sparse import vstack, hstack, issparse, csr_matrix as sparse
 
-from idx_gen import PG, QG
-from idx_brch import F_BUS, T_BUS
-from idx_cost import MODEL, POLYNOMIAL
+from pypower.idx_gen import PG, QG
+from pypower.idx_brch import F_BUS, T_BUS
+from pypower.idx_cost import MODEL, POLYNOMIAL
 
-from polycost import polycost
-from d2Sbus_dV2 import d2Sbus_dV2
-from dSbr_dV import dSbr_dV
-from dIbr_dV import dIbr_dV
-from d2AIbr_dV2 import d2AIbr_dV2
-from d2ASbr_dV2 import d2ASbr_dV2
-from opf_costfcn import opf_costfcn
-from opf_consfcn import opf_consfcn
+from pypower.polycost import polycost
+from pypower.d2Sbus_dV2 import d2Sbus_dV2
+from pypower.dSbr_dV import dSbr_dV
+from pypower.dIbr_dV import dIbr_dV
+from pypower.d2AIbr_dV2 import d2AIbr_dV2
+from pypower.d2ASbr_dV2 import d2ASbr_dV2
+from pypower.opf_costfcn import opf_costfcn
+from pypower.opf_consfcn import opf_consfcn
 
 
 def opf_hessfcn(x, lmbda, om, Ybus, Yf, Yt, ppopt, il=None, cost_mult=1.0):
@@ -235,10 +235,10 @@ def opf_hessfcn(x, lmbda, om, Ybus, Yf, Yt, ppopt, il=None, cost_mult=1.0):
         d2G_err = max(max(abs(d2G - num_d2G)))
         d2H_err = max(max(abs(d2H - num_d2H)))
         if d2f_err > 1e-6:
-            print 'Max difference in d2f: %g' % d2f_err
+            print('Max difference in d2f: %g' % d2f_err)
         if d2G_err > 1e-5:
-            print 'Max difference in d2G: %g' % d2G_err
+            print('Max difference in d2G: %g' % d2G_err)
         if d2H_err > 1e-6:
-            print 'Max difference in d2H: %g' % d2H_err
+            print('Max difference in d2H: %g' % d2H_err)
 
     return d2f + d2G + d2H

--- a/pypower/pfsoln.py
+++ b/pypower/pfsoln.py
@@ -22,9 +22,9 @@ from numpy import flatnonzero as find
 
 from scipy.sparse import csr_matrix
 
-from idx_bus import VM, VA, PD, QD
-from idx_gen import GEN_BUS, GEN_STATUS, PG, QG, QMIN, QMAX
-from idx_brch import F_BUS, T_BUS, BR_STATUS, PF, PT, QF, QT
+from pypower.idx_bus import VM, VA, PD, QD
+from pypower.idx_gen import GEN_BUS, GEN_STATUS, PG, QG, QMIN, QMAX
+from pypower.idx_brch import F_BUS, T_BUS, BR_STATUS, PF, PT, QF, QT
 
 EPS = finfo(float).eps
 

--- a/pypower/pips.py
+++ b/pypower/pips.py
@@ -348,22 +348,22 @@ def pips(f_fcn, x0=None, A=None, l=None, u=None, xmin=None, xmax=None,
     if opt["verbose"]:
         s = '-sc' if opt["step_control"] else ''
         v = pipsver('all')
-        print 'Python Interior Point Solver - PIPS%s, Version %s, %s' % \
-                    (s, v['Version'], v['Date'])
+        print('Python Interior Point Solver - PIPS%s, Version %s, %s' %
+                    (s, v['Version'], v['Date']))
         if opt['verbose'] > 1:
-            print " it    objective   step size   feascond     gradcond     " \
-                  "compcond     costcond  "
-            print "----  ------------ --------- ------------ ------------ " \
-                  "------------ ------------"
-            print "%3d  %12.8g %10s %12g %12g %12g %12g" % \
+            print(" it    objective   step size   feascond     gradcond     "
+                  "compcond     costcond  ")
+            print("----  ------------ --------- ------------ ------------ "
+                  "------------ ------------")
+            print("%3d  %12.8g %10s %12g %12g %12g %12g" %
                 (i, (f / opt["cost_mult"]), "",
-                 feascond, gradcond, compcond, costcond)
+                 feascond, gradcond, compcond, costcond))
 
     if feascond < opt["feastol"] and gradcond < opt["gradtol"] and \
         compcond < opt["comptol"] and costcond < opt["costtol"]:
         converged = True
         if opt["verbose"]:
-            print "Converged!"
+            print("Converged!")
 
     # do Newton iterations
     while (not converged) and (i < opt["max_it"]):
@@ -375,9 +375,9 @@ def pips(f_fcn, x0=None, A=None, l=None, u=None, xmin=None, xmax=None,
                  "ineqnonlin": mu[range(niqnln)]}
         if nonlinear:
             if hess_fcn is None:
-                print "pips: Hessian evaluation via finite differences " \
-                      "not yet implemented.\nPlease provide " \
-                      "your own hessian evaluation function."
+                print("pips: Hessian evaluation via finite differences "
+                      "not yet implemented.\nPlease provide "
+                      "your own hessian evaluation function.")
             Lxx = hess_fcn(x, lmbda, opt["cost_mult"])
         else:
             _, _, d2f = f_fcn(x, True)      # cost
@@ -400,7 +400,7 @@ def pips(f_fcn, x0=None, A=None, l=None, u=None, xmin=None, xmax=None,
 
         if any(isnan(dxdlam)):
             if opt["verbose"]:
-                print '\nNumerically Failed\n'
+                print('\nNumerically Failed\n')
             eflag = -1
             break
 
@@ -486,7 +486,7 @@ def pips(f_fcn, x0=None, A=None, l=None, u=None, xmin=None, xmax=None,
                 L1 = f1 + dot(lam, g1) + dot(mu, h1 + z) - gamma * sum(log(z))
 
                 if opt["verbose"] > 2:
-                    print "   %3d            %10.5f" % (-j, norm(dx1))
+                    print("   %3d            %10.5f" % (-j, norm(dx1)))
 
                 rho = (L1 - L) / (dot(Lx, dx1) + 0.5 * dot(dx1, Lxx * dx1))
 
@@ -570,20 +570,20 @@ def pips(f_fcn, x0=None, A=None, l=None, u=None, xmin=None, xmax=None,
             'alphap': alphap, 'alphad': alphad})
 
         if opt["verbose"] > 1:
-            print "%3d  %12.8g %10.5g %12g %12g %12g %12g" % \
+            print("%3d  %12.8g %10.5g %12g %12g %12g %12g" %
                 (i, (f / opt["cost_mult"]), norm(dx), feascond, gradcond,
-                 compcond, costcond)
+                 compcond, costcond))
 
         if feascond < opt["feastol"] and gradcond < opt["gradtol"] and \
             compcond < opt["comptol"] and costcond < opt["costtol"]:
             converged = True
             if opt["verbose"]:
-                print "Converged!"
+                print("Converged!")
         else:
             if any(isnan(x)) or (alphap < alpha_min) or \
                 (alphad < alpha_min) or (gamma < EPS) or (gamma > 1.0 / EPS):
                 if opt["verbose"]:
-                    print "Numerically failed."
+                    print("Numerically failed.")
                 eflag = -1
                 break
             f0 = f
@@ -593,7 +593,7 @@ def pips(f_fcn, x0=None, A=None, l=None, u=None, xmin=None, xmax=None,
 
     if opt["verbose"]:
         if not converged:
-            print "Did not converge in %d iterations." % i
+            print("Did not converge in %d iterations." % i)
 
     # package results
     if eflag != -1:

--- a/pypower/pipsopf_solver.py
+++ b/pypower/pipsopf_solver.py
@@ -20,17 +20,17 @@
 from numpy import ones, zeros, Inf, pi, exp, conj, r_
 from numpy import flatnonzero as find
 
-from idx_bus import BUS_TYPE, REF, VM, VA, MU_VMAX, MU_VMIN, LAM_P, LAM_Q
-from idx_brch import F_BUS, T_BUS, RATE_A, PF, QF, PT, QT, MU_SF, MU_ST
-from idx_gen import GEN_BUS, PG, QG, VG, MU_PMAX, MU_PMIN, MU_QMAX, MU_QMIN
-from idx_cost import MODEL, PW_LINEAR, NCOST
+from pypower.idx_bus import BUS_TYPE, REF, VM, VA, MU_VMAX, MU_VMIN, LAM_P, LAM_Q
+from pypower.idx_brch import F_BUS, T_BUS, RATE_A, PF, QF, PT, QT, MU_SF, MU_ST
+from pypower.idx_gen import GEN_BUS, PG, QG, VG, MU_PMAX, MU_PMIN, MU_QMAX, MU_QMIN
+from pypower.idx_cost import MODEL, PW_LINEAR, NCOST
 
-from makeYbus import makeYbus
-from opf_costfcn import opf_costfcn
-from opf_consfcn import opf_consfcn
-from opf_hessfcn import opf_hessfcn
-from pips import pips
-from util import sub2ind
+from pypower.makeYbus import makeYbus
+from pypower.opf_costfcn import opf_costfcn
+from pypower.opf_consfcn import opf_consfcn
+from pypower.opf_hessfcn import opf_hessfcn
+from pypower.pips import pips
+from pypower.util import sub2ind
 
 def pipsopf_solver(om, ppopt, out_opt=None):
     """Solves AC optimal power flow using PIPS.

--- a/pypower/poly2pwl.py
+++ b/pypower/poly2pwl.py
@@ -19,9 +19,9 @@
 
 from numpy import ones, zeros, r_
 
-from idx_cost import MODEL, COST, NCOST, PW_LINEAR
+from pypower.idx_cost import MODEL, COST, NCOST, PW_LINEAR
 
-from totcost import totcost
+from pypower.totcost import totcost
 
 
 def poly2pwl(polycost, Pmin, Pmax, npts):

--- a/pypower/polycost.py
+++ b/pypower/polycost.py
@@ -21,7 +21,7 @@ import sys
 
 from numpy import zeros, arange, flatnonzero as find
 
-from idx_cost import MODEL, NCOST, PW_LINEAR, COST
+from pypower.idx_cost import MODEL, NCOST, PW_LINEAR, COST
 
 
 def polycost(gencost, Pg, der=0):

--- a/pypower/printpf.py
+++ b/pypower/printpf.py
@@ -25,16 +25,16 @@ from numpy import \
 
 from numpy import flatnonzero as find
 
-from idx_bus import BUS_I, BUS_TYPE, PD, QD, GS, BS, BUS_AREA, VM, VA, \
+from pypower.idx_bus import BUS_I, BUS_TYPE, PD, QD, GS, BS, BUS_AREA, VM, VA, \
     VMAX, VMIN, LAM_P, LAM_Q, MU_VMAX, MU_VMIN
-from idx_gen import GEN_BUS, PG, QG, QMAX, QMIN, VG, GEN_STATUS, \
+from pypower.idx_gen import GEN_BUS, PG, QG, QMAX, QMIN, VG, GEN_STATUS, \
     PMAX, PMIN, MU_PMAX, MU_PMIN, MU_QMAX, MU_QMIN
-from idx_brch import F_BUS, T_BUS, BR_R, BR_X, BR_B, RATE_A, \
+from pypower.idx_brch import F_BUS, T_BUS, BR_R, BR_X, BR_B, RATE_A, \
     TAP, SHIFT, BR_STATUS, PF, QF, PT, QT, MU_SF, MU_ST
 
-from isload import isload
-from run_userfcn import run_userfcn
-from ppoption import ppoption
+from pypower.isload import isload
+from pypower.run_userfcn import run_userfcn
+from pypower.ppoption import ppoption
 
 
 def printpf(baseMVA, bus=None, gen=None, branch=None, f=None, success=None,
@@ -690,7 +690,7 @@ def printpf(baseMVA, bus=None, gen=None, branch=None, f=None, success=None,
             fd.write('\n')
 
     ## execute userfcn callbacks for 'printpf' stage
-    if have_results_struct & results.has_key('userfcn'):
+    if have_results_struct and ('userfcn' in results):
         run_userfcn(results["userfcn"], 'printpf', results, fd, ppopt)
 
     ## print raw data for Perl database interface

--- a/pypower/qps_pips.py
+++ b/pypower/qps_pips.py
@@ -22,7 +22,7 @@ from numpy import Inf, ones, zeros, dot
 
 from scipy.sparse import csr_matrix as sparse
 
-from pips import pips
+from pypower.pips import pips
 
 
 def qps_pips(H, c, A, l, u, xmin=None, xmax=None, x0=None, opt=None):
@@ -150,7 +150,7 @@ def qps_pips(H, c, A, l, u, xmin=None, xmax=None, x0=None, opt=None):
            'xmax' not in p:
 #           'xmin' not in p or len(p['xmin']) == 0 and \
 #           'xmax' not in p or len(p['xmax']) == 0:
-            print 'qps_pips: LP problem must include constraints or variable bounds'
+            print('qps_pips: LP problem must include constraints or variable bounds')
             return
         else:
             if p['A'] is not None and p['A'].nnz >= 0:

--- a/pypower/rundcopf.py
+++ b/pypower/rundcopf.py
@@ -17,8 +17,8 @@
 """Runs a DC optimal power flow.
 """
 
-from ppoption import ppoption
-from runopf import runopf
+from pypower.ppoption import ppoption
+from pypower.runopf import runopf
 
 def rundcopf(casedata='case9', ppopt=None, fname='', solvedcase=''):
     """Runs a DC optimal power flow.

--- a/pypower/rundcpf.py
+++ b/pypower/rundcpf.py
@@ -17,8 +17,8 @@
 """Runs a DC power flow.
 """
 
-from ppoption import ppoption
-from runpf import runpf
+from pypower.ppoption import ppoption
+from pypower.runpf import runpf
 
 
 def rundcpf(casedata='case9', ppopt=None, fname='', solvedcase=''):

--- a/pypower/runduopf.py
+++ b/pypower/runduopf.py
@@ -17,8 +17,8 @@
 """Runs a DC optimal power flow with unit-decommitment heuristic.
 """
 
-from ppoption import ppoption
-from runuopf import runuopf
+from pypower.ppoption import ppoption
+from pypower.runuopf import runuopf
 
 
 def runduopf(casedata='case9', ppopt=None, fname='', solvedcase=''):

--- a/pypower/runopf.py
+++ b/pypower/runopf.py
@@ -19,10 +19,10 @@
 
 from sys import stdout, stderr
 
-from ppoption import ppoption
-from opf import opf
-from printpf import printpf
-from savecase import savecase
+from pypower.ppoption import ppoption
+from pypower.opf import opf
+from pypower.printpf import printpf
+from pypower.savecase import savecase
 
 
 def runopf(casedata='case9', ppopt=None, fname='', solvedcase=''):
@@ -41,7 +41,7 @@ def runopf(casedata='case9', ppopt=None, fname='', solvedcase=''):
         fd = None
         try:
             fd = open(fname, "wb")
-        except IOError, detail:
+        except IOError as detail:
             stderr.write("Error opening %s: %s.\n" % (fname, detail))
         finally:
             if fd is not None:

--- a/pypower/runpf.py
+++ b/pypower/runpf.py
@@ -24,27 +24,27 @@ from time import time
 from numpy import r_, c_, ix_, zeros, pi, ones, exp, argmax
 from numpy import flatnonzero as find
 
-from bustypes import bustypes
-from ext2int import ext2int
-from loadcase import loadcase
-from ppoption import ppoption
-from ppver import ppver
-from makeBdc import makeBdc
-from makeSbus import makeSbus
-from dcpf import dcpf
-from makeYbus import makeYbus
-from newtonpf import newtonpf
-from fdpf import fdpf
-from gausspf import gausspf
-from makeB import makeB
-from pfsoln import pfsoln
-from printpf import printpf
-from savecase import savecase
-from int2ext import int2ext
+from pypower.bustypes import bustypes
+from pypower.ext2int import ext2int
+from pypower.loadcase import loadcase
+from pypower.ppoption import ppoption
+from pypower.ppver import ppver
+from pypower.makeBdc import makeBdc
+from pypower.makeSbus import makeSbus
+from pypower.dcpf import dcpf
+from pypower.makeYbus import makeYbus
+from pypower.newtonpf import newtonpf
+from pypower.fdpf import fdpf
+from pypower.gausspf import gausspf
+from pypower.makeB import makeB
+from pypower.pfsoln import pfsoln
+from pypower.printpf import printpf
+from pypower.savecase import savecase
+from pypower.int2ext import int2ext
 
-from idx_bus import PD, QD, VM, VA, GS, BUS_TYPE, PQ
-from idx_brch import PF, PT, QF, QT
-from idx_gen import PG, QG, VG, QMAX, QMIN, GEN_BUS, GEN_STATUS
+from pypower.idx_bus import PD, QD, VM, VA, GS, BUS_TYPE, PQ
+from pypower.idx_brch import PF, PT, QF, QT
+from pypower.idx_gen import PG, QG, VG, QMAX, QMIN, GEN_BUS, GEN_STATUS
 
 
 def runpf(casedata='case9', ppopt=None, fname='', solvedcase=''):
@@ -190,9 +190,9 @@ def runpf(casedata='case9', ppopt=None, fname='', solvedcase=''):
                     if len(pv):
                         if verbose:
                             if len(mx) > 0:
-                                print 'Gen %d [only one left] exceeds upper Q limit : INFEASIBLE PROBLEM\n' % mx
+                                print('Gen %d [only one left] exceeds upper Q limit : INFEASIBLE PROBLEM\n' % mx)
                             else:
-                                print 'Gen %d [only one left] exceeds lower Q limit : INFEASIBLE PROBLEM\n' % mn
+                                print('Gen %d [only one left] exceeds lower Q limit : INFEASIBLE PROBLEM\n' % mn)
 
                         success = 0
                         break
@@ -209,10 +209,10 @@ def runpf(casedata='case9', ppopt=None, fname='', solvedcase=''):
                             mn = []
 
                     if verbose and len(mx) > 0:
-                        print 'Gen %d at upper Q limit, converting to PQ bus\n' % mx
+                        print('Gen %d at upper Q limit, converting to PQ bus\n' % mx)
 
                     if verbose and len(mn) > 0:
-                        print 'Gen %d at lower Q limit, converting to PQ bus\n' % mn
+                        print('Gen %d at lower Q limit, converting to PQ bus\n' % mn)
 
                     ## save corresponding limit values
                     fixedQg[mx] = gen[mx, QMAX]
@@ -232,7 +232,7 @@ def runpf(casedata='case9', ppopt=None, fname='', solvedcase=''):
                     ref_temp = ref
                     ref, pv, pq = bustypes(bus, gen)
                     if verbose and ref != ref_temp:
-                        print 'Bus %d is new slack bus\n' % ref
+                        print('Bus %d is new slack bus\n' % ref)
 
                     limited = r_[limited, mx]
                 else:
@@ -271,7 +271,7 @@ def runpf(casedata='case9', ppopt=None, fname='', solvedcase=''):
         fd = None
         try:
             fd = open(fname, "wb")
-        except Exception, detail:
+        except Exception as detail:
             stderr.write("Error opening %s: %s.\n" % (fname, detail))
         finally:
             if fd is not None:

--- a/pypower/runuopf.py
+++ b/pypower/runuopf.py
@@ -19,10 +19,10 @@
 
 from sys import stderr
 
-from ppoption import ppoption
-from uopf import uopf
-from printpf import printpf
-from savecase import savecase
+from pypower.ppoption import ppoption
+from pypower.uopf import uopf
+from pypower.printpf import printpf
+from pypower.savecase import savecase
 
 
 def runuopf(casedata='case9', ppopt=None, fname='', solvedcase=''):
@@ -41,7 +41,7 @@ def runuopf(casedata='case9', ppopt=None, fname='', solvedcase=''):
         fd = None
         try:
             fd = open(fname, "wb")
-        except Exception, detail:
+        except Exception as detail:
             stderr.write("Error opening %s: %s.\n" % (fname, detail))
         finally:
             if fd is not None:

--- a/pypower/savecase.py
+++ b/pypower/savecase.py
@@ -24,13 +24,18 @@ from os.path import basename
 from numpy import array, c_, r_, any
 from scipy.io import savemat
 
-from run_userfcn import run_userfcn
+from pypower._compat import PY2
+from pypower.run_userfcn import run_userfcn
 
-from idx_bus import MU_VMIN, VMIN
-from idx_gen import PMIN, MU_PMAX, MU_PMIN, MU_QMIN, MU_QMAX, APF
-from idx_brch import MU_ST, MU_SF, BR_STATUS, PF, PT, QT, QF, ANGMAX, MU_ANGMAX
-from idx_area import PRICE_REF_BUS
-from idx_cost import MODEL, NCOST, PW_LINEAR, POLYNOMIAL
+from pypower.idx_bus import MU_VMIN, VMIN
+from pypower.idx_gen import PMIN, MU_PMAX, MU_PMIN, MU_QMIN, MU_QMAX, APF
+from pypower.idx_brch import MU_ST, MU_SF, BR_STATUS, PF, PT, QT, QF, ANGMAX, MU_ANGMAX
+from pypower.idx_area import PRICE_REF_BUS
+from pypower.idx_cost import MODEL, NCOST, PW_LINEAR, POLYNOMIAL
+
+
+if not PY2:
+    basestring = str
 
 
 def savecase(fname, ppc, comment=None, version='2'):
@@ -101,7 +106,7 @@ def savecase(fname, ppc, comment=None, version='2'):
     else:                       ## Python file
         try:
             fd = open(fname, "wb")
-        except Exception, detail:
+        except Exception as detail:
             stderr.write("savecase: %s.\n" % detail)
             return fname
 

--- a/pypower/scale_load.py
+++ b/pypower/scale_load.py
@@ -24,10 +24,10 @@ from numpy import flatnonzero as find
 
 from scipy.sparse import csr_matrix as sparse
 
-from isload import isload
+from pypower.isload import isload
 
-from idx_bus import PD, QD, BUS_AREA, BUS_I
-from idx_gen import PG, QG, QMAX, QMIN, GEN_BUS, GEN_STATUS, PMIN
+from pypower.idx_bus import PD, QD, BUS_AREA, BUS_I
+from pypower.idx_gen import PG, QG, QMAX, QMIN, GEN_BUS, GEN_STATUS, PMIN
 
 
 def scale_load(load, bus, gen=None, load_zone=None, opt=None):

--- a/pypower/set_reorder.py
+++ b/pypower/set_reorder.py
@@ -38,8 +38,8 @@ def set_reorder(A, B, idx, dim=0):
         elif dim == 1:
             A[:, idx] = B
         else:
-            raise ValueError, 'dim (%d) may be 0 or 1' % dim
+            raise ValueError('dim (%d) may be 0 or 1' % dim)
     else:
-        raise ValueError, 'number of dimensions (%d) may be 1 or 2' % dim
+        raise ValueError('number of dimensions (%d) may be 1 or 2' % dim)
 
     return A

--- a/pypower/t/t_begin.py
+++ b/pypower/t/t_begin.py
@@ -38,4 +38,4 @@ def t_begin(num_of_tests, quiet=False):
     TestGlobals.t_clock = time()
 
     if not TestGlobals.t_quiet:
-        print '1..%d' % num_of_tests
+        print('1..%d' % num_of_tests)

--- a/pypower/t/t_ext2int2ext.py
+++ b/pypower/t/t_ext2int2ext.py
@@ -135,9 +135,9 @@ def t_ext2int2ext(quiet=False):
 
     t = 'val = ext2int(ppc, val, {\'branch\', \'gen\', \'bus\'})'
     got = ext2int(ppc, ppce['xrows'], ['branch', 'gen', 'bus'])
-    ex = r_[ppce['xbranch'][range(6) + range(7, 10), :4],
+    ex = r_[ppce['xbranch'][list(range(6)) + list(range(7, 10)), :4],
             ppce['xgen'][[3, 1, 0], :],
-            ppce['xbus'][range(5) + range(6, 10), :4],
+            ppce['xbus'][list(range(5)) + list(range(6, 10)), :4],
             -1 * ones((2, 4))]
     t_is(got, ex, 12, t)
     t = 'val = int2ext(ppc, val, oldval, {\'branch\', \'gen\', \'bus\'})'
@@ -153,9 +153,9 @@ def t_ext2int2ext(quiet=False):
 
     t = 'val = ext2int(ppc, val, {\'branch\', \'gen\', \'bus\'}, 1)'
     got = ext2int(ppc, ppce['xcols'], ['branch', 'gen', 'bus'], 1)
-    ex = r_[ppce['xbranch'][range(6) + range(7, 10), :4],
+    ex = r_[ppce['xbranch'][list(range(6)) + list(range(7, 10)), :4],
             ppce['xgen'][[3, 1, 0], :],
-            ppce['xbus'][range(5) + range(6, 10), :4],
+            ppce['xbus'][list(range(5)) + list(range(6, 10)), :4],
             -1 * ones((2, 4))].T
     t_is(got, ex, 12, t)
     t = 'val = int2ext(ppc, val, oldval, {\'branch\', \'gen\', \'bus\'}, 1)'
@@ -224,9 +224,9 @@ def t_ext2int2ext(quiet=False):
     t_is(got['xbranch'], ppce['xbranch'], 12, t)
 
     t = 'ppc = ext2int(ppc, field, {\'branch\', \'gen\', \'bus\'})'
-    ex = r_[ppce['xbranch'][range(6) + range(7, 10), :4],
+    ex = r_[ppce['xbranch'][list(range(6)) + list(range(7, 10)), :4],
             ppce['xgen'][[3, 1, 0], :],
-            ppce['xbus'][range(5) + range(6, 10), :4],
+            ppce['xbus'][list(range(5)) + list(range(6, 10)), :4],
             -1 * ones((2, 4))]
     got = ext2int(ppc, 'xrows', ['branch', 'gen', 'bus'])
     t_is(got['xrows'], ex, 12, t)
@@ -235,9 +235,9 @@ def t_ext2int2ext(quiet=False):
     t_is(got['xrows'], ppce['xrows'], 12, t)
 
     t = 'ppc = ext2int(ppc, field, {\'branch\', \'gen\', \'bus\'}, 1)'
-    ex = r_[ppce['xbranch'][range(6) + range(7, 10), :4],
+    ex = r_[ppce['xbranch'][list(range(6)) + list(range(7, 10)), :4],
             ppce['xgen'][[3, 1, 0], :],
-            ppce['xbus'][range(5) + range(6, 10), :4],
+            ppce['xbus'][list(range(5)) + list(range(6, 10)), :4],
             -1 * ones((2, 4))].T
     got = ext2int(ppc, 'xcols', ['branch', 'gen', 'bus'], 1)
     t_is(got['xcols'], ex, 12, t)
@@ -310,8 +310,8 @@ def t_ext2int2ext(quiet=False):
     t = 'ppc = ext2int(ppc) - A, N are DC sized : '
     ppce = loadcase(t_case_ext())
     ppci = loadcase(t_case_int())
-    eVmQgcols = range(10, 20) + range(24, 28)
-    iVmQgcols = range(9, 18) + range(21, 24)
+    eVmQgcols = list(range(10, 20)) + list(range(24, 28))
+    iVmQgcols = list(range(9, 18)) + list(range(21, 24))
     ppce['A'] = delete(ppce['A'], eVmQgcols, 1)
     ppce['N'] = delete(ppce['N'], eVmQgcols, 1)
     ppci['A'] = delete(ppci['A'], iVmQgcols, 1)

--- a/pypower/t/t_is.py
+++ b/pypower/t/t_is.py
@@ -90,7 +90,7 @@ def t_is(got, expected, prec=5, msg=''):
             else:
                 s += '        expected: %d x %d\n' % expected.shape
 
-        print s
+        print(s)
 
 if __name__ == '__main__':
     a = array([[1,2,3], [4,5,6]])

--- a/pypower/t/t_ok.py
+++ b/pypower/t/t_ok.py
@@ -44,6 +44,6 @@ def t_ok(cond, msg=''):
 
     if not TestGlobals.t_quiet:
         s += 'ok %3d%s' % (TestGlobals.t_counter, msg)
-        print s
+        print(s)
 
     TestGlobals.t_counter += 1

--- a/pypower/t/t_runopf_w_res.py
+++ b/pypower/t/t_runopf_w_res.py
@@ -75,7 +75,7 @@ def t_runopf_w_res(quiet=False):
 
     t = 'extra offline gen : ';
     ppc = loadcase(casefile)
-    idx = range(3) +[4]+ range(3, 6)
+    idx = list(range(3)) + [4] + list(range(3, 6))
     ppc['gen'] = ppc['gen'][idx, :]
     ppc['gencost'] = ppc['gencost'][idx, :]
     ppc['reserves']['zones'] = ppc['reserves']['zones'][:, idx]
@@ -94,7 +94,7 @@ def t_runopf_w_res(quiet=False):
 
     t = 'both extra & gen 6 no res : ';
     ppc = loadcase(casefile)
-    idx = range(3) +[4]+ range(3, 6)
+    idx = list(range(3)) + [4] + list(range(3, 6))
     ppc['gen'] = ppc['gen'][idx, :]
     ppc['gencost'] = ppc['gencost'][idx, :]
     ppc['reserves']['zones'] = ppc['reserves']['zones'][:, idx]

--- a/pypower/t/t_scale_load.py
+++ b/pypower/t/t_scale_load.py
@@ -340,7 +340,7 @@ def t_scale_load(quiet=False):
     err = 0
     try:
         bus, gen = scale_load(load, ppc['bus'], ppc['gen'], None, opt)
-    except ScalingError, e:
+    except ScalingError as e:
         expected = 'scale_load: impossible to make zone 2 load equal 80 by scaling non-existent dispatchable load'
         err = expected not in str(e)
     t_ok(err, t)

--- a/pypower/t/t_skip.py
+++ b/pypower/t/t_skip.py
@@ -34,8 +34,8 @@ def t_skip(cnt, msg=''):
 
     TestGlobals.t_skip_cnt = TestGlobals.t_skip_cnt + cnt
     if not TestGlobals.t_quiet:
-        print 'skipped tests %d..%d%s' % (TestGlobals.t_counter,
+        print('skipped tests %d..%d%s' % (TestGlobals.t_counter,
                                             TestGlobals.t_counter + cnt - 1,
-                                            msg)
+                                            msg))
 
     TestGlobals.t_counter = TestGlobals.t_counter + cnt

--- a/pypower/total_load.py
+++ b/pypower/total_load.py
@@ -24,10 +24,15 @@ from numpy import flatnonzero as find
 
 from scipy.sparse import csr_matrix as sparse
 
-from isload import isload
+from pypower._compat import PY2
+from pypower.isload import isload
 
-from idx_bus import PD, QD, BUS_AREA, BUS_I
-from idx_gen import QMAX, QMIN, GEN_BUS, GEN_STATUS, PMIN
+from pypower.idx_bus import PD, QD, BUS_AREA, BUS_I
+from pypower.idx_gen import QMAX, QMIN, GEN_BUS, GEN_STATUS, PMIN
+
+
+if not PY2:
+    basestring = str
 
 
 def total_load(bus, gen=None, load_zone=None, which_type=None):
@@ -80,7 +85,7 @@ def total_load(bus, gen=None, load_zone=None, which_type=None):
     want_disp   = (which_type[0] == 'B') | (which_type[0] == 'D')
 
     ## initialize load_zone
-    if isinstance(load_zone, basestring) & (load_zone == 'all'):
+    if isinstance(load_zone, basestring) and (load_zone == 'all'):
         load_zone = ones(nb, int)                  ## make a single zone of all buses
     elif len(load_zone) == 0:
         load_zone = bus[:, BUS_AREA].astype(int)   ## use areas defined in bus data as zones
@@ -100,7 +105,7 @@ def total_load(bus, gen=None, load_zone=None, which_type=None):
     ## dispatchable load at each bus
     if want_disp:            ## need dispatchable
         ng = gen.shape[0]
-        is_ld = isload(gen) & (gen[:, GEN_STATUS] > 0)
+        is_ld = isload(gen) and (gen[:, GEN_STATUS] > 0)
         ld = find(is_ld)
 
         ## create map of external bus numbers to bus indices

--- a/pypower/totcost.py
+++ b/pypower/totcost.py
@@ -20,8 +20,8 @@
 from numpy import zeros, arange
 from numpy import flatnonzero as find
 
-from polycost import polycost
-from idx_cost import PW_LINEAR, POLYNOMIAL, COST, NCOST, MODEL
+from pypower.polycost import polycost
+from pypower.idx_cost import PW_LINEAR, POLYNOMIAL, COST, NCOST, MODEL
 
 
 def totcost(gencost, Pg):

--- a/pypower/uopf.py
+++ b/pypower/uopf.py
@@ -23,15 +23,15 @@ from copy import deepcopy
 
 from numpy import flatnonzero as find
 
-from opf_args import opf_args2
-from ppoption import ppoption
-from isload import isload
-from totcost import totcost
-from fairmax import fairmax
-from opf import opf
+from pypower.opf_args import opf_args2
+from pypower.ppoption import ppoption
+from pypower.isload import isload
+from pypower.totcost import totcost
+from pypower.fairmax import fairmax
+from pypower.opf import opf
 
-from idx_bus import PD
-from idx_gen import GEN_STATUS, PG, QG, PMIN, MU_PMIN
+from pypower.idx_bus import PD
+from pypower.idx_gen import GEN_STATUS, PG, QG, PMIN, MU_PMIN
 
 
 def uopf(*args):
@@ -75,7 +75,7 @@ def uopf(*args):
         i = on[i]                     ## convert to generator index
 
         if verbose:
-            print 'Shutting down generator %d so all Pmin limits can be satisfied.\n' % i
+            print('Shutting down generator %d so all Pmin limits can be satisfied.\n' % i)
 
         ## set generation to zero
         ppc["gen"][i, [PG, QG, GEN_STATUS]] = 0
@@ -126,7 +126,7 @@ def uopf(*args):
         else:
             ## shutting something else down helps, so let's keep going
             if verbose:
-                print 'Shutting down generator %d.\n' % k1
+                print('Shutting down generator %d.\n' % k1)
 
             results0 = deepcopy(results1)
             ppc["bus"] = results0["bus"].copy()     ## use these V as starting point for OPF


### PR DESCRIPTION
PYPOWER should now work on Python 2 and 3 with the same codebase. I tested it
with 2.7 and 3.3, but 2.6 should also work. I don’t think support for older
Python versions is still necessary.

I couldn’t run all tests, because that also wasn’t possible with v4.0.1, but
all tests that passed with 4.0.1 are still passing. I also performed some
power flow computations and they also worked fine.

I didn’t apply all changes 2to3 suggested. The remaining ones are in
https://gist.github.com/sscherfke/9462075 (just in case ...).
