### PR TITLE
Update makeBdc.py

### DIFF
--- a/pypower/makeBdc.py
+++ b/pypower/makeBdc.py
@@ -64,7 +64,7 @@ def makeBdc(baseMVA, bus, branch):
 
     ## build Bf such that Bf * Va is the vector of real branch powers injected
     ## at each branch's "from" bus
-    Bf = sparse((r_[b, -b], (i, r_[f, t])))## = spdiags(b, 0, nl, nl) * Cft
+    Bf = sparse((r_[b, -b], (i, r_[f, t])), shape = (nl, nb))## = spdiags(b, 0, nl, nl) * Cft
 
     ## build Bbus
     Bbus = Cft.T * Bf


### PR DESCRIPTION
This is a matpower error. MakeBdc sparse command creates a Bf matrix with wrong dimensions if the last bus is a DC line-connected bus because its last row is an empty row. Explicitly passing the matrix dimensions solves the issue.