### PR TITLE
Transpose input array to spsolve in dcpf

### DIFF
--- a/pypower/dcpf.py
+++ b/pypower/dcpf.py
@@ -5,7 +5,7 @@
 """Solves a DC power flow.
 """
 
-from numpy import copy, r_, matrix
+from numpy import copy, r_, matrix, transpose
 from scipy.sparse.linalg import spsolve
 
 
@@ -30,6 +30,6 @@ def dcpf(B, Pbus, Va0, ref, pv, pq):
     Va = copy(Va0)
 
     ## update angles for non-reference buses
-    Va[pvpq] = spsolve(B[pvpq.T, pvpq], Pbus[pvpq] - B[pvpq.T, ref] * Va0[ref])
+    Va[pvpq] = spsolve(B[pvpq.T, pvpq], transpose(Pbus[pvpq] - B[pvpq.T, ref] * Va0[ref]))
 
     return Va


### PR DESCRIPTION
DCPF does not work otherwise on recent scipy installations.
This solves issue #16 