### PR TITLE
Fix index error in numpy 1.12

### DIFF
--- a/pypower/opf_hessfcn.py
+++ b/pypower/opf_hessfcn.py
@@ -141,7 +141,7 @@ def opf_hessfcn(x, lmbda, om, Ybus, Yf, Yt, ppopt, il=None, cost_mult=1.0):
     d2f = d2f * cost_mult
 
     ##----- evaluate Hessian of power balance constraints -----
-    nlam = len(lmbda["eqnonlin"]) / 2
+    nlam = int(len(lmbda["eqnonlin"]) / 2)
     lamP = lmbda["eqnonlin"][:nlam]
     lamQ = lmbda["eqnonlin"][nlam:nlam + nlam]
     Gpaa, Gpav, Gpva, Gpvv = d2Sbus_dV2(Ybus, V, lamP)
@@ -161,7 +161,7 @@ def opf_hessfcn(x, lmbda, om, Ybus, Yf, Yt, ppopt, il=None, cost_mult=1.0):
         ], "csr")
 
     ##----- evaluate Hessian of flow constraints -----
-    nmu = len(lmbda["ineqnonlin"]) / 2
+    nmu = int(len(lmbda["ineqnonlin"]) / 2)
     muF = lmbda["ineqnonlin"][:nmu]
     muT = lmbda["ineqnonlin"][nmu:nmu + nmu]
     if ppopt['OPF_FLOW_LIM'] == 2:       ## current

--- a/pypower/pipsopf_solver.py
+++ b/pypower/pipsopf_solver.py
@@ -210,7 +210,7 @@ def pipsopf_solver(om, ppopt, out_opt=None):
     pimul = r_[
         results["mu"]["nln"]["l"] - results["mu"]["nln"]["u"],
         results["mu"]["lin"]["l"] - results["mu"]["lin"]["u"],
-        -ones(ny > 0),
+        -ones(int(ny > 0)),
         results["mu"]["var"]["l"] - results["mu"]["var"]["u"],
     ]
     raw = {'xr': x, 'pimul': pimul, 'info': info, 'output': output}

--- a/pypower/totcost.py
+++ b/pypower/totcost.py
@@ -36,7 +36,7 @@ def totcost(gencost, Pg):
 
             for i in ipwl:
                 ncost = gencost[i, NCOST]
-                for k in arange(ncost - 1):
+                for k in arange(ncost - 1,dtype=int):
                     p1, p2 = p[i, k], p[i, k+1]
                     c1, c2 = c[i, k], c[i, k+1]
                     m = (c2 - c1) / (p2 - p1)


### PR DESCRIPTION
Fixed Index Error in numpy 1.12 : Index deprecated warning from numpy < 1.12 has turned into an error, the indexes made by arithmetic operation should be explicitly converted to integers.
