### PR TITLE
Temcdrm

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Installation
 
 PYPOWER depends upon:
 
-* Python_ 2.6-3.5 and
+* Python_ 2.6-3.6 and
 * SciPy_ 0.9 or later.
 
 It can be installed using pip_::
@@ -74,7 +74,7 @@ License & Copyright
 ===================
 
 Copyright (c) 1996-2015, Power System Engineering Research Center (PSERC)  
-Copyright (c) 2010-2015 Richard Lincoln  
+Copyright (c) 2010-2018 Richard Lincoln  
 
 The code in PYPOWER is distributed under the 3-clause BSD license
 below. The PYPOWER case files distributed with PYPOWER are not covered

--- a/pypower/dcopf_solver.py
+++ b/pypower/dcopf_solver.py
@@ -267,7 +267,7 @@ def dcopf_solver(om, ppopt, out_opt=None):
 
     pimul = r_[
       mu_l - mu_u,
-     -ones((ny > 0)), ## dummy entry corresponding to linear cost row in A
+     -ones(int(ny > 0)), ## dummy entry corresponding to linear cost row in A
       muLB - muUB
     ]
 

--- a/pypower/ext2int.py
+++ b/pypower/ext2int.py
@@ -91,9 +91,11 @@ def ext2int(ppc, val_or_field=None, ordering=None, dim=0):
 
             ## save data matrices with external ordering
             if 'ext' not in o: o['ext'] = {}
-            o["ext"]["bus"]    = ppc["bus"].copy().astype(int)
-            o["ext"]["branch"] = ppc["branch"].copy().astype(int)
-            o["ext"]["gen"]    = ppc["gen"].copy().astype(int)
+            ## Note: these dictionaries contain mixed float/int data, 
+            ## so don't cast them all astype(int) for numpy/scipy indexing
+            o["ext"]["bus"]    = ppc["bus"].copy()
+            o["ext"]["branch"] = ppc["branch"].copy()
+            o["ext"]["gen"]    = ppc["gen"].copy()
             if 'areas' in ppc:
                 if len(ppc["areas"]) == 0: ## if areas field is empty
                     del ppc['areas']       ## delete it (so it's ignored)
@@ -109,7 +111,7 @@ def ext2int(ppc, val_or_field=None, ordering=None, dim=0):
             ## determine which buses, branches, gens are connected and
             ## in-service
             n2i = sparse((range(nb), (ppc["bus"][:, BUS_I], zeros(nb))),
-                         shape=(max(ppc["bus"][:, BUS_I]) + 1, 1))
+                         shape=(max(ppc["bus"][:, BUS_I].astype(int)) + 1, 1))
             n2i = array( n2i.todense().flatten() )[0, :] # as 1D array
             bs = (bt != NONE)                               ## bus status
             o["bus"]["status"]["on"]  = find(  bs )         ## connected

--- a/pypower/ppver.py
+++ b/pypower/ppver.py
@@ -12,8 +12,8 @@ def ppver(*args):
     """
 
     ver = {'Name': 'PYTPOWER',
-           'Version': '5.0.0',
+           'Version': '5.1.4',
            'Release':  '',
-           'Date': '29-May-2015'}
+           'Date': '27-June-2018'}
 
     return ver

--- a/pypower/ppver.py
+++ b/pypower/ppver.py
@@ -11,7 +11,7 @@ def ppver(*args):
     @author: Ray Zimmerman (PSERC Cornell)
     """
 
-    ver = {'Name': 'PYTPOWER',
+    ver = {'Name': 'PYPOWER',
            'Version': '5.1.4',
            'Release':  '',
            'Date': '27-June-2018'}

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='PYPOWER',
-    version='5.1.3',
+    version='5.1.4',
     author='Richard Lincoln',
     author_email='r.w.lincoln@gmail.com',
     description='Solves power flow and optimal power flow problems',


### PR DESCRIPTION
The December 2017 pull request broke the "pf" and "opf" solutions because some floating point solution values, e.g. bus voltage magnitudes and angles, were truncated to integer.  Symptoms include inf and nan loss values, along with per-unit voltages less than 1.000 being truncated to zero.  Tested that "pf" and "opf" solutions are giving the same answers as before using the current versions of numpy and scipy, with these changes.  What other regression tests should be done?  Should there be a test suite?

We have an upcoming release of TESP that depends on this fix to PYPOWER, so please expedite this merge if possible.  As we continue to rely on PYPOWER directly, I'm willing to set up a test suite if that would help.