### PR TITLE
Update polycost.py to prevent failure for purely piecewise linear cases

### DIFF
--- a/pypower/polycost.py
+++ b/pypower/polycost.py
@@ -28,6 +28,10 @@ def polycost(gencost, Pg, der=0):
 
     @author: Ray Zimmerman (PSERC Cornell)
     """
+    if gencost.size == 0:
+        #User has a purely linear piecewise problem, exit early with empty array
+        return []
+
     if any(gencost[:, MODEL] == PW_LINEAR):
         sys.stderr.write('polycost: all costs must be polynomial\n')
 


### PR DESCRIPTION
This function is called by multiple sub-functions of runopf(). When a case is defined with only piecewise linear gencost functions (i.e. no polynomial cost functions) the 'polycost' function fails. The gencost usually passed into this function is often "polycost(gencost[ipol, :], xx[ipol], 1)" as in opf_costfcn.py:105, which in this edge case means gencost is an empty array. The empty gencost array doesn't trigger the if statement on line 35, and then causes line 35 to fail, as taking the max of an empty array throws an error.

The proposed change causes this function to return an empty array immediately if gencost is empty (i.e. if all cost functions are peicewise linear) to ensure that the OPF can continue without error. The change has been tested locally and produces the expected result (runopf() solves for a case of only piecewise linear costcurves).