### PR TITLE
Upgrade Python to 3.5 in Deploy Stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ deploy:
     tags: true
     repo: rwl/PYPOWER
     branch: master
-    python: '2.7'
+    python: '3.5'


### PR DESCRIPTION
This might just fix the issues Travis CI is having. pip has namely dropped support for 2.7 some time ago.