### PR TITLE
Fix/numpy deprecated imports

### DIFF
--- a/pypower/dcopf_solver.py
+++ b/pypower/dcopf_solver.py
@@ -9,8 +9,9 @@ from sys import stderr
 
 from copy import deepcopy
 
+from math import inf
 from numpy import \
-    array, zeros, ones, any, diag, r_, pi, Inf, isnan, arange, c_, dot
+    array, zeros, ones, any, diag, r_, pi, isnan, arange, c_, dot
 
 from numpy import flatnonzero as find
 
@@ -187,8 +188,8 @@ def dcopf_solver(om, ppopt, out_opt=None):
         Varefs = bus[bus[:, BUS_TYPE] == REF, VA] * (pi / 180.0)
 
         lb, ub = xmin.copy(), xmax.copy()
-        lb[xmin == -Inf] = -1e10   ## replace Inf with numerical proxies
-        ub[xmax ==  Inf] =  1e10
+        lb[xmin == -inf] = -1e10   ## replace inf with numerical proxies
+        ub[xmax ==  inf] =  1e10
         x0 = (lb + ub) / 2;
         # angles set to first reference angle
         x0[vv["i1"]["Va"]:vv["iN"]["Va"]] = Varefs[0]

--- a/pypower/fdpf.py
+++ b/pypower/fdpf.py
@@ -6,8 +6,8 @@
 """
 
 import sys
-
-from numpy import array, angle, exp, linalg, conj, r_, Inf
+from math import inf
+from numpy import array, angle, exp, linalg, conj, r_
 from scipy.sparse.linalg import splu
 
 from pypower.ppoption import ppoption
@@ -60,8 +60,8 @@ def fdpf(Ybus, Sbus, V0, Bp, Bpp, ref, pv, pq, ppopt=None):
     Q = mis[pq].imag
 
     ## check tolerance
-    normP = linalg.norm(P, Inf)
-    normQ = linalg.norm(Q, Inf)
+    normP = linalg.norm(P, inf)
+    normQ = linalg.norm(Q, inf)
     if verbose > 1:
         sys.stdout.write('\niteration     max mismatch (p.u.)  ')
         sys.stdout.write('\ntype   #        P            Q     ')
@@ -98,8 +98,8 @@ def fdpf(Ybus, Sbus, V0, Bp, Bpp, ref, pv, pq, ppopt=None):
         Q = mis[pq].imag
 
         ## check tolerance
-        normP = linalg.norm(P, Inf)
-        normQ = linalg.norm(Q, Inf)
+        normP = linalg.norm(P, inf)
+        normQ = linalg.norm(Q, inf)
         if verbose > 1:
             sys.stdout.write("\n  %s  %3d   %10.3e   %10.3e" %
                              (type,i, normP, normQ))
@@ -123,8 +123,8 @@ def fdpf(Ybus, Sbus, V0, Bp, Bpp, ref, pv, pq, ppopt=None):
         Q = mis[pq].imag
 
         ## check tolerance
-        normP = linalg.norm(P, Inf)
-        normQ = linalg.norm(Q, Inf)
+        normP = linalg.norm(P, inf)
+        normQ = linalg.norm(Q, inf)
         if verbose > 1:
             sys.stdout.write('\n  Q  %3d   %10.3e   %10.3e' % (i, normP, normQ))
         if normP < tol and normQ < tol:

--- a/pypower/gausspf.py
+++ b/pypower/gausspf.py
@@ -6,8 +6,8 @@
 """
 
 import sys
-
-from numpy import linalg, conj, r_, Inf, ndarray
+from math import inf
+from numpy import linalg, conj, r_, ndarray
 
 from pypower.ppoption import ppoption
 
@@ -61,7 +61,7 @@ def gausspf(Ybus, Sbus, V0, ref, pv, pq, ppopt=None):
              mis[pq].imag   ]
 
     ## check tolerance
-    normF = linalg.norm(F, Inf)
+    normF = linalg.norm(F, inf)
     if verbose > 1:
         sys.stdout.write('\n it    max P & Q mismatch (p.u.)')
         sys.stdout.write('\n----  ---------------------------')
@@ -99,7 +99,7 @@ def gausspf(Ybus, Sbus, V0, ref, pv, pq, ppopt=None):
                  mis[pq].imag  ]
 
         ## check for convergence
-        normF = linalg.norm(F, Inf)
+        normF = linalg.norm(F, inf)
         if verbose > 1:
             sys.stdout.write('\n%3d        %10.3e' % (i, normF))
         if normF < tol:

--- a/pypower/gurobi_options.py
+++ b/pypower/gurobi_options.py
@@ -2,7 +2,8 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from numpy import Inf
+from math import inf
+
 from pypower._compat import PY2
 from pypower.util import feval
 
@@ -100,7 +101,7 @@ def gurobi_options(overrides=None, ppopt=None):
     if verbose:
         opt['DisplayInterval'] = 1
     else:
-        opt['DisplayInterval'] = Inf
+        opt['DisplayInterval'] = inf
 
     ##-----  call user function to modify defaults  -----
     if len(fname) > 0:

--- a/pypower/ipoptopf_solver.py
+++ b/pypower/ipoptopf_solver.py
@@ -5,7 +5,8 @@
 """Solves AC optimal power flow using IPOPT.
 """
 
-from numpy import ones, zeros, shape, Inf, pi, exp, conj, r_, arange
+from math import inf
+from numpy import ones, zeros, shape, pi, exp, conj, r_, arange
 from numpy import flatnonzero as find
 
 from scipy.sparse import issparse, tril, vstack, hstack, csr_matrix as sparse
@@ -87,8 +88,8 @@ def ipoptopf_solver(om, ppopt):
 
     ## try to select an interior initial point
     ll = xmin.copy(); uu = xmax.copy()
-    ll[xmin == -Inf] = -2e19   ## replace Inf with numerical proxies
-    uu[xmax ==  Inf] =  2e19
+    ll[xmin == -inf] = -2e19   ## replace inf with numerical proxies
+    uu[xmax ==  inf] =  2e19
     x0 = (ll + uu) / 2
     Varefs = bus[bus[:, BUS_TYPE] == REF, VA] * (pi / 180)
     x0[vv['i1']['Va']:vv['iN']['Va']] = Varefs[0]  ## angles set to first reference angle
@@ -196,7 +197,7 @@ def ipoptopf_solver(om, ppopt):
     # number of constraints
     m = neqnln + niqnln + nA
     # lower bound of constraint
-    gl = r_[zeros(neqnln), -Inf * ones(niqnln), l]
+    gl = r_[zeros(neqnln), -inf * ones(niqnln), l]
     # upper bound of constraints
     gu = r_[zeros(neqnln),       zeros(niqnln), u]
 

--- a/pypower/makeAang.py
+++ b/pypower/makeAang.py
@@ -5,7 +5,8 @@
 """Construct constraints for branch angle difference limits.
 """
 
-from numpy import array, ones, zeros, r_, Inf, pi, arange
+from math import inf
+from numpy import array, ones, zeros, r_, pi, arange
 from numpy import flatnonzero as find
 from scipy.sparse import csr_matrix as sparse
 
@@ -47,7 +48,7 @@ def makeAang(baseMVA, branch, nb, ppopt):
             jj = r_[branch[iang, F_BUS], branch[iang, T_BUS]]
             Aang = sparse((r_[ones(nang), -ones(nang)],
                            (ii, jj)), (nang, nb))
-            uang = Inf * ones(nang)
+            uang = inf * ones(nang)
             lang = -uang
             lang[iangl] = branch[iang[iangl], ANGMIN] * pi / 180
             uang[iangh] = branch[iang[iangh], ANGMAX] * pi / 180

--- a/pypower/newtonpf.py
+++ b/pypower/newtonpf.py
@@ -6,8 +6,8 @@
 """
 
 import sys
-
-from numpy import array, angle, exp, linalg, conj, r_, Inf
+from math import inf
+from numpy import array, angle, exp, linalg, conj, r_
 
 from scipy.sparse import hstack, vstack
 
@@ -68,7 +68,7 @@ def newtonpf(Ybus, Sbus, V0, ref, pv, pq, ppopt=None):
              mis[pq].imag  ]
 
     ## check tolerance
-    normF = linalg.norm(F, Inf)
+    normF = linalg.norm(F, inf)
     if verbose > 1:
         sys.stdout.write('\n it    max P & Q mismatch (p.u.)')
         sys.stdout.write('\n----  ---------------------------')
@@ -116,7 +116,7 @@ def newtonpf(Ybus, Sbus, V0, ref, pv, pq, ppopt=None):
                  mis[pq].imag  ]
 
         ## check for convergence
-        normF = linalg.norm(F, Inf)
+        normF = linalg.norm(F, inf)
         if verbose > 1:
             sys.stdout.write('\n%3d        %10.3e' % (i, normF))
         if normF < tol:

--- a/pypower/opf_consfcn.py
+++ b/pypower/opf_consfcn.py
@@ -4,8 +4,13 @@
 
 """Evaluates nonlinear constraints and their Jacobian for OPF.
 """
+try:
+    from math import inf
+except ImportError:
+    # in python < 3.5, inf is not defined in math
+    from numpy import inf
 
-from numpy import zeros, ones, conj, exp, r_, Inf, arange
+from numpy import zeros, ones, conj, exp, r_, arange
 
 from scipy.sparse import lil_matrix, vstack, hstack, csr_matrix as sparse
 
@@ -96,7 +101,7 @@ def opf_consfcn(x, om, Ybus, Yf, Yt, ppopt, il=None, *args):
     ## then, the inequality constraints (branch flow limits)
     if nl2 > 0:
         flow_max = (branch[il, RATE_A] / baseMVA)**2
-        flow_max[flow_max == 0] = Inf
+        flow_max[flow_max == 0] = inf
         if ppopt['OPF_FLOW_LIM'] == 2:       ## current magnitude limit, |I|
             If = Yf * V
             It = Yt * V

--- a/pypower/opf_model.py
+++ b/pypower/opf_model.py
@@ -8,7 +8,8 @@ problem formulation.
 
 from sys import stderr
 
-from numpy import array, zeros, ones, Inf, dot, arange, r_
+from math import inf
+from numpy import array, zeros, ones, dot, arange, r_
 from numpy import flatnonzero as find
 from scipy.sparse import lil_matrix, csr_matrix as sparse
 
@@ -217,11 +218,11 @@ class opf_model(object):
                 varsets = []
 
             N, M = AorN.shape
-            if len(l) == 0:                   ## default l is -Inf
-                l = -Inf * ones(N)
+            if len(l) == 0:                   ## default l is -inf
+                l = -inf * ones(N)
 
-            if len(u) == 0:                   ## default u is Inf
-                u = Inf * ones(N)
+            if len(u) == 0:                   ## default u is inf
+                u = inf * ones(N)
 
             if len(varsets) == 0:
                 varsets = self.var["order"]
@@ -394,10 +395,10 @@ class opf_model(object):
             v0 = zeros(N)           ## init to zero by default
 
         if vl is None or len(vl) == 0:
-            vl = -Inf * ones(N)     ## unbounded below by default
+            vl = -inf * ones(N)     ## unbounded below by default
 
         if vu is None or len(vu) == 0:
-            vu = Inf * ones(N)      ## unbounded above by default
+            vu = inf * ones(N)      ## unbounded above by default
 
 
         ## add info about this var set
@@ -720,7 +721,7 @@ class opf_model(object):
 
         if self.lin["N"]:
             A = lil_matrix((self.lin["N"], self.var["N"]))
-            u = Inf * ones(self.lin["N"])
+            u = inf * ones(self.lin["N"])
             l = -u
         else:
             A = None

--- a/pypower/opf_setup.py
+++ b/pypower/opf_setup.py
@@ -6,9 +6,9 @@
 """
 
 from sys import stdout, stderr
-
+from math import inf
 from numpy import array, any, delete, unique, arange, nonzero, pi, \
-    r_, ones, Inf
+    r_, ones
 from numpy import flatnonzero as find
 
 from scipy.sparse import hstack, csr_matrix as sparse
@@ -144,7 +144,7 @@ def opf_setup(ppc, ppopt):
         ## branch flow constraints
         il = find((branch[:, RATE_A] != 0) & (branch[:, RATE_A] < 1e10))
         nl2 = len(il)         ## number of constrained lines
-        lpf = -Inf * ones(nl2)
+        lpf = -inf * ones(nl2)
         upf = branch[il, RATE_A] / baseMVA - Pfinj[il]
         upt = branch[il, RATE_A] / baseMVA + Pfinj[il]
 
@@ -166,7 +166,7 @@ def opf_setup(ppc, ppopt):
         ycon_vars = ['Pg', 'Qg', 'y']
 
     ## voltage angle reference constraints
-    Vau = Inf * ones(nb)
+    Vau = inf * ones(nb)
     Val = -Vau
     Vau[refs] = Va[refs]
     Val[refs] = Va[refs]

--- a/pypower/pips.py
+++ b/pypower/pips.py
@@ -4,8 +4,8 @@
 
 """Python Interior Point Solver (PIPS).
 """
-
-from numpy import array, Inf, any, isnan, ones, r_, finfo, \
+from math import inf
+from numpy import array, any, isnan, ones, r_, finfo, \
     zeros, dot, absolute, log, flatnonzero as find
 
 from numpy.linalg import norm
@@ -186,10 +186,10 @@ def pips(f_fcn, x0=None, A=None, l=None, u=None, xmin=None, xmax=None,
     nA = A.shape[0] if A is not None else 0 # number of original linear constr
 
     # default argument values
-    if l is None or len(l) == 0: l = -Inf * ones(nA)
-    if u is None or len(u) == 0: u =  Inf * ones(nA)
-    if xmin is None or len(xmin) == 0: xmin = -Inf * ones(x0.shape[0])
-    if xmax is None or len(xmax) == 0: xmax =  Inf * ones(x0.shape[0])
+    if l is None or len(l) == 0: l = -inf * ones(nA)
+    if u is None or len(u) == 0: u =  inf * ones(nA)
+    if xmin is None or len(xmin) == 0: xmin = -inf * ones(x0.shape[0])
+    if xmax is None or len(xmax) == 0: xmax =  inf * ones(x0.shape[0])
     if gh_fcn is None:
         nonlinear = False
         gn = array([])
@@ -320,15 +320,15 @@ def pips(f_fcn, x0=None, A=None, l=None, u=None, xmin=None, xmax=None,
 
     maxh = zeros(1) if len(h) == 0 else max(h)
 
-    gnorm = norm(g, Inf) if len(g) else 0.0
-    lam_norm = norm(lam, Inf) if len(lam) else 0.0
-    mu_norm = norm(mu, Inf) if len(mu) else 0.0
-    znorm = norm(z, Inf) if len(z) else 0.0
+    gnorm = norm(g, inf) if len(g) else 0.0
+    lam_norm = norm(lam, inf) if len(lam) else 0.0
+    mu_norm = norm(mu, inf) if len(mu) else 0.0
+    znorm = norm(z, inf) if len(z) else 0.0
     feascond = \
-        max([gnorm, maxh]) / (1 + max([norm(x, Inf), znorm]))
+        max([gnorm, maxh]) / (1 + max([norm(x, inf), znorm]))
     gradcond = \
-        norm(Lx, Inf) / (1 + max([lam_norm, mu_norm]))
-    compcond = dot(z, mu) / (1 + norm(x, Inf))
+        norm(Lx, inf) / (1 + max([lam_norm, mu_norm]))
+    compcond = dot(z, mu) / (1 + norm(x, inf))
     costcond = absolute(f - f0) / (1 + absolute(f0))
 
     # save history
@@ -448,14 +448,14 @@ def pips(f_fcn, x0=None, A=None, l=None, u=None, xmin=None, xmax=None,
 
             maxh1 = zeros(1) if len(h1) == 0 else max(h1)
 
-            g1norm = norm(g1, Inf) if len(g1) else 0.0
-            lam1_norm = norm(lam, Inf) if len(lam) else 0.0
-            mu1_norm = norm(mu, Inf) if len(mu) else 0.0
-            z1norm = norm(z, Inf) if len(z) else 0.0
+            g1norm = norm(g1, inf) if len(g1) else 0.0
+            lam1_norm = norm(lam, inf) if len(lam) else 0.0
+            mu1_norm = norm(mu, inf) if len(mu) else 0.0
+            z1norm = norm(z, inf) if len(z) else 0.0
 
             feascond1 = max([ g1norm, maxh1 ]) / \
-                (1 + max([ norm(x1, Inf), z1norm ]))
-            gradcond1 = norm(Lx1, Inf) / (1 + max([ lam1_norm, mu1_norm ]))
+                (1 + max([ norm(x1, inf), z1norm ]))
+            gradcond1 = norm(Lx1, inf) / (1 + max([ lam1_norm, mu1_norm ]))
 
             if (feascond1 > feascond) and (gradcond1 > gradcond):
                 sc = True
@@ -544,15 +544,15 @@ def pips(f_fcn, x0=None, A=None, l=None, u=None, xmin=None, xmax=None,
         else:
             maxh = max(h)
 
-        gnorm = norm(g, Inf) if len(g) else 0.0
-        lam_norm = norm(lam, Inf) if len(lam) else 0.0
-        mu_norm = norm(mu, Inf) if len(mu) else 0.0
-        znorm = norm(z, Inf) if len(z) else 0.0
+        gnorm = norm(g, inf) if len(g) else 0.0
+        lam_norm = norm(lam, inf) if len(lam) else 0.0
+        mu_norm = norm(mu, inf) if len(mu) else 0.0
+        znorm = norm(z, inf) if len(z) else 0.0
         feascond = \
-            max([gnorm, maxh]) / (1 + max([norm(x, Inf), znorm]))
+            max([gnorm, maxh]) / (1 + max([norm(x, inf), znorm]))
         gradcond = \
-            norm(Lx, Inf) / (1 + max([lam_norm, mu_norm]))
-        compcond = dot(z, mu) / (1 + norm(x, Inf))
+            norm(Lx, inf) / (1 + max([lam_norm, mu_norm]))
+        compcond = dot(z, mu) / (1 + norm(x, inf))
         costcond = float(absolute(f - f0) / (1 + absolute(f0)))
 
         hist.append({'feascond': feascond, 'gradcond': gradcond,

--- a/pypower/pipsopf_solver.py
+++ b/pypower/pipsopf_solver.py
@@ -5,7 +5,8 @@
 """Solves AC optimal power flow using PIPS.
 """
 
-from numpy import ones, zeros, Inf, pi, exp, conj, r_
+from math import inf
+from numpy import ones, zeros, pi, exp, conj, r_
 from numpy import flatnonzero as find
 
 from pypower.idx_bus import BUS_TYPE, REF, VM, VA, MU_VMAX, MU_VMIN, LAM_P, LAM_Q
@@ -108,8 +109,8 @@ def pipsopf_solver(om, ppopt, out_opt=None):
 
     ## try to select an interior initial point
     ll, uu = xmin.copy(), xmax.copy()
-    ll[xmin == -Inf] = -1e10   ## replace Inf with numerical proxies
-    uu[xmax ==  Inf] =  1e10
+    ll[xmin == -inf] = -1e10   ## replace inf with numerical proxies
+    uu[xmax ==  inf] =  1e10
     x0 = (ll + uu) / 2
     Varefs = bus[bus[:, BUS_TYPE] == REF, VA] * (pi / 180)
     ## angles set to first reference angle

--- a/pypower/ppoption.py
+++ b/pypower/ppoption.py
@@ -5,9 +5,6 @@
 """Used to set and retrieve a PYPOWER options vector.
 """
 
-from numpy import Inf
-
-
 PF_OPTIONS = [
     ('pf_alg', 1, '''power flow algorithm:
 1 - Newton's method,
@@ -184,7 +181,7 @@ GUROBI_OPTIONS = [
 3 - concurrent (LP only)
 4 - deterministic concurrent (LP only)
 '''),
-    ('grb_timelimit', Inf, 'maximum time allowed for solver (TimeLimit)'),
+    ('grb_timelimit', float('inf'), 'maximum time allowed for solver (TimeLimit)'),
 ('grb_threads', 0, '(auto) maximum number of threads to use (Threads)'),
 ('grb_opt', 0, 'See gurobi_options() for details')
 ]

--- a/pypower/qps_cplex.py
+++ b/pypower/qps_cplex.py
@@ -8,8 +8,8 @@
 import re
 
 from sys import stdout, stderr
-
-from numpy import array, NaN, Inf, ones, zeros, shape, finfo, arange, r_
+from math import inf
+from numpy import array, NaN, ones, zeros, shape, finfo, arange, r_
 from numpy import flatnonzero as find
 
 from scipy.sparse import csr_matrix as sparse
@@ -122,22 +122,22 @@ def qps_cplex(H, c, A, l, u, xmin, xmax, x0, opt):
     if len(c) == 0:
         c = zeros(nx)
 
-    if  len(A) > 0 and (len(l) == 0 or all(l == -Inf)) and \
-                       (len(u) == 0 or all(u ==  Inf)):
+    if  len(A) > 0 and (len(l) == 0 or all(l == -inf)) and \
+                       (len(u) == 0 or all(u ==  inf)):
         A = None                    ## no limits => no linear constraints
 
     nA = shape(A)[0]                ## number of original linear constraints
     if len(u) == 0:                 ## By default, linear inequalities are ...
-        u = Inf * ones(nA)          ## ... unbounded above and ...
+        u = inf * ones(nA)          ## ... unbounded above and ...
 
     if len(l) == 0:
-        l = -Inf * ones(nA)         ## ... unbounded below.
+        l = -inf * ones(nA)         ## ... unbounded below.
 
     if len(xmin) == 0:              ## By default, optimization variables are ...
-        xmin = -Inf * ones(nx)      ## ... unbounded below and ...
+        xmin = -inf * ones(nx)      ## ... unbounded below and ...
 
     if len(xmax) == 0:
-        xmax = Inf * ones(nx)       ## ... unbounded above.
+        xmax = inf * ones(nx)       ## ... unbounded above.
 
     if len(x0) == 0:
         x0 = zeros(nx)

--- a/pypower/qps_cplex.py
+++ b/pypower/qps_cplex.py
@@ -8,8 +8,8 @@
 import re
 
 from sys import stdout, stderr
-from math import inf
-from numpy import array, NaN, ones, zeros, shape, finfo, arange, r_
+from math import inf, nan
+from numpy import array, ones, zeros, shape, finfo, arange, r_
 from numpy import flatnonzero as find
 
 from scipy.sparse import csr_matrix as sparse
@@ -231,18 +231,18 @@ def qps_cplex(H, c, A, l, u, xmin, xmax, x0, opt):
 
     ## check for empty results (in case optimization failed)
     if len(x) == 0:
-        x = NaN * zeros(nx)
+        x = nan * zeros(nx)
 
     if len(f) == 0:
-        f = NaN
+        f = nan
 
     if len(lam) == 0:
-        lam['ineqlin'] = NaN * zeros(len(bi))
-        lam['eqlin']   = NaN * zeros(len(be))
-        lam['lower']   = NaN * zeros(nx)
-        lam['upper']   = NaN * zeros(nx)
-        mu_l        = NaN * zeros(nA)
-        mu_u        = NaN * zeros(nA)
+        lam['ineqlin'] = nan * zeros(len(bi))
+        lam['eqlin']   = nan * zeros(len(be))
+        lam['lower']   = nan * zeros(nx)
+        lam['upper']   = nan * zeros(nx)
+        mu_l        = nan * zeros(nA)
+        mu_u        = nan * zeros(nA)
     else:
         mu_l        = zeros(nA)
         mu_u        = zeros(nA)

--- a/pypower/qps_gurobi.py
+++ b/pypower/qps_gurobi.py
@@ -7,7 +7,7 @@
 
 from sys import stderr
 from math import inf
-from numpy import ones, zeros, shape, finfo, abs
+from numpy import ones, zeros, shape, finfo, abs, nan
 from numpy import flatnonzero as find
 
 from scipy.sparse import issparse, csr_matrix as sparse
@@ -245,18 +245,18 @@ def qps_gurobi(H, c, A, l, u, xmin, xmax, x0, opt):
     ## check for empty results (in case optimization failed)
     lam = {}
     if len(x) == 0:
-        x = NaN(nx, 1);
-        lam['lower']   = NaN(nx)
-        lam['upper']   = NaN(nx)
+        x = nan(nx, 1);
+        lam['lower']   = nan(nx)
+        lam['upper']   = nan(nx)
     else:
         lam['lower']   = zeros(nx)
         lam['upper']   = zeros(nx)
 
     if len(f) == 0:
-        f = NaN
+        f = nan
 
     if len(pi) == 0:
-        pi  = NaN(len(bb))
+        pi  = nan(len(bb))
 
     kl = find(rc > 0);   ## lower bound binding
     ku = find(rc < 0);   ## upper bound binding

--- a/pypower/qps_gurobi.py
+++ b/pypower/qps_gurobi.py
@@ -6,8 +6,8 @@
 """
 
 from sys import stderr
-
-from numpy import Inf, ones, zeros, shape, finfo, abs
+from math import inf
+from numpy import ones, zeros, shape, finfo, abs
 from numpy import flatnonzero as find
 
 from scipy.sparse import issparse, csr_matrix as sparse
@@ -153,17 +153,17 @@ def qps_gurobi(H, c, A, l, u, xmin, xmax, x0, opt):
     if len(c) == 0:
         c = zeros(nx)
 
-    if  len(A) > 0 and (len(l) == 0 or all(l == -Inf)) and \
-                       (len(u) == 0 or all(u ==  Inf)):
+    if  len(A) > 0 and (len(l) == 0 or all(l == -inf)) and \
+                       (len(u) == 0 or all(u ==  inf)):
         A = None                    ## no limits => no linear constraints
 
     nA = shape(A)[0]                ## number of original linear constraints
     if nA:
         if len(u) == 0:             ## By default, linear inequalities are ...
-            u = Inf * ones(nA)      ## ... unbounded above and ...
+            u = inf * ones(nA)      ## ... unbounded above and ...
 
         if len(l) == 0:
-            l = -Inf * ones(nA)     ## ... unbounded below.
+            l = -inf * ones(nA)     ## ... unbounded below.
 
     if len(x0) == 0:
         x0 = zeros(nx)
@@ -189,7 +189,7 @@ def qps_gurobi(H, c, A, l, u, xmin, xmax, x0, opt):
     if verbose:
         g_opt['DisplayInterval'] = 1
     else:
-        g_opt['DisplayInterval'] = Inf
+        g_opt['DisplayInterval'] = inf
 
     if not issparse(A):
         A = sparse(A)

--- a/pypower/qps_ipopt.py
+++ b/pypower/qps_ipopt.py
@@ -4,13 +4,12 @@
 
 """Quadratic Program Solver based on IPOPT.
 """
-
-from sys import stderr
-
-from numpy import Inf, ones, zeros, shape, tril
+from math import inf
+from numpy import ones, zeros, shape, tril
 from numpy import flatnonzero as find
 
 from scipy.sparse import issparse, csr_matrix as sparse
+from sys import stderr
 
 try:
     import pyipopt
@@ -161,17 +160,17 @@ def qps_ipopt(H, c, A, l, u, xmin, xmax, x0, opt):
     if len(c) == 0:
         c = zeros(nx)
 
-    if  len(A) > 0 and (len(l) == 0 or all(l == -Inf)) and \
-                       (len(u) == 0 or all(u ==  Inf)):
+    if  len(A) > 0 and (len(l) == 0 or all(l == -inf)) and \
+                       (len(u) == 0 or all(u ==  inf)):
         A = None                    ## no limits => no linear constraints
 
     nA = shape(A)[0]                ## number of original linear constraints
     if nA:
         if len(u) == 0:             ## By default, linear inequalities are ...
-            u = Inf * ones(nA)      ## ... unbounded above and ...
+            u = inf * ones(nA)      ## ... unbounded above and ...
 
         if len(l) == 0:
-            l = -Inf * ones(nA)     ## ... unbounded below.
+            l = -inf * ones(nA)     ## ... unbounded below.
 
     if len(x0) == 0:
         x0 = zeros(nx)

--- a/pypower/qps_mosek.py
+++ b/pypower/qps_mosek.py
@@ -5,12 +5,11 @@
 """Quadratic Program Solver based on MOSEK.
 """
 
-import re
-
-from sys import stdout, stderr
-
-from numpy import array, Inf, zeros, shape, tril, any
+from math import inf
+from numpy import array, zeros, shape, tril, any
 from numpy import flatnonzero as find
+import re
+from sys import stdout, stderr
 
 from scipy.sparse import csr_matrix as sparse
 
@@ -170,8 +169,8 @@ def qps_mosek(H, c=None, A=None, l=None, u=None, xmin=None, xmax=None,
     if 'a' not in prob | len(prob['a']) == 0:
         unconstrained = True
         prob['a'] = sparse((1, (1, 1)), (1, nx))
-        prob.blc = -Inf
-        prob.buc =  Inf
+        prob.blc = -inf
+        prob.buc =  inf
     else:
         unconstrained = False
 

--- a/pypower/qps_pips.py
+++ b/pypower/qps_pips.py
@@ -5,8 +5,9 @@
 """Uses the Python Interior Point Solver (PIPS) to solve QP (quadratic
 programming) problems.
 """
+from math import inf
 
-from numpy import Inf, ones, zeros, dot
+from numpy import ones, zeros, dot
 
 from scipy.sparse import csr_matrix as sparse
 
@@ -152,8 +153,8 @@ def qps_pips(H, c, A, l, u, xmin=None, xmax=None, x0=None, opt=None):
     else:
         nx = p['H'].shape[0]
 
-    p['xmin'] = -Inf * ones(nx) if 'xmin' not in p else p['xmin']
-    p['xmax'] =  Inf * ones(nx) if 'xmax' not in p else p['xmax']
+    p['xmin'] = -inf * ones(nx) if 'xmin' not in p else p['xmin']
+    p['xmax'] =  inf * ones(nx) if 'xmax' not in p else p['xmax']
 
     p['c'] = zeros(nx) if p['c'] is None else p['c']
 

--- a/pypower/t/t_dcline.py
+++ b/pypower/t/t_dcline.py
@@ -7,7 +7,7 @@
 
 from os.path import dirname, join
 
-from numpy import array, ones, zeros, Inf, r_, ix_, argsort, arange
+from numpy import array, r_, arange
 from numpy import flatnonzero as find
 
 from pypower.ppoption import ppoption

--- a/pypower/t/t_opf_dc_gurobi.py
+++ b/pypower/t/t_opf_dc_gurobi.py
@@ -7,7 +7,8 @@
 
 from os.path import dirname, join
 
-from numpy import array, ones, Inf, arange, r_
+from math import inf
+from numpy import array, ones, arange, r_
 
 from scipy.io import loadmat
 from scipy.sparse import csr_matrix as sparse
@@ -114,7 +115,7 @@ def t_opf_dc_gurobi(quiet=False):
             col = [9, 10, 12, 10, 11, 13]
             ppc['A'] = sparse(([-1, 1, -1, 1, -1, -1], (row, col)), (2, 14))
             ppc['u'] = array([0, 0])
-            ppc['l'] = array([-Inf, -Inf])
+            ppc['l'] = array([-inf, -inf])
             ppc['zl'] = array([0, 0])
 
             ppc['N'] = sparse(([1, 1], ([0, 1], [12, 13])), (2, 14))  ## new z variables only
@@ -136,7 +137,7 @@ def t_opf_dc_gurobi(quiet=False):
             col = [18, 19, 24, 19, 20, 25]
             ppc['A'] = sparse(([-1, 1, -1, 1, -1, -1], (row, col)), (2, 26))
             ppc['u'] = array([0, 0])
-            ppc['l'] = array([-Inf, -Inf])
+            ppc['l'] = array([-inf, -inf])
             ppc['zl'] = array([0, 0])
 
             ppc['N'] = sparse(([1, 1], ([0, 1], [24, 25])), (2, 26))   ## new z variables only
@@ -156,7 +157,7 @@ def t_opf_dc_gurobi(quiet=False):
             ## with A and N sized for DC opf
             ppc = loadcase(casefile)
             ppc['A'] = sparse(([1, 1], ([0, 0], [9, 10])), (1, 14))   ## Pg1 + Pg2
-            ppc['u'] = array([Inf])
+            ppc['u'] = array([inf])
             ppc['l'] = array([600])
             r = rundcopf(ppc, ppopt)
             t_ok(not r['success'], [t, 'no success'])

--- a/pypower/t/t_opf_dc_pips.py
+++ b/pypower/t/t_opf_dc_pips.py
@@ -6,8 +6,8 @@
 """
 
 from os.path import dirname, join
-
-from numpy import array, ones, Inf, arange, r_
+from math import inf
+from numpy import array, ones, arange, r_
 
 from scipy.io import loadmat
 from scipy.sparse import csr_matrix as sparse
@@ -98,7 +98,7 @@ def t_opf_dc_pips(quiet=False):
     col = [9, 10, 12, 10, 11, 13]
     ppc['A'] = sparse(([-1, 1, -1, 1, -1, -1], (row, col)), (2, 14))
     ppc['u'] = array([0, 0])
-    ppc['l'] = array([-Inf, -Inf])
+    ppc['l'] = array([-inf, -inf])
     ppc['zl'] = array([0, 0])
 
     ppc['N'] = sparse(([1, 1], ([0, 1], [12, 13])), (2, 14))   ## new z variables only
@@ -120,7 +120,7 @@ def t_opf_dc_pips(quiet=False):
     col = [18, 19, 24, 19, 20, 25]
     ppc['A'] = sparse(([-1, 1, -1, 1, -1, -1], (row, col)), (2, 26))
     ppc['u'] = array([0, 0])
-    ppc['l'] = array([-Inf, -Inf])
+    ppc['l'] = array([-inf, -inf])
     ppc['zl'] = array([0, 0])
 
     ppc['N'] = sparse(([1, 1], ([0, 1], [24, 25])), (2, 26))   ## new z variables only
@@ -140,7 +140,7 @@ def t_opf_dc_pips(quiet=False):
     ## with A and N sized for DC opf
     ppc = loadcase(casefile)
     ppc['A'] = sparse(([1, 1], ([0, 0], [9, 10])), (1, 14))   ## Pg1 + Pg2
-    ppc['u'] = array([Inf])
+    ppc['u'] = array([inf])
     ppc['l'] = array([600])
     r = rundcopf(ppc, ppopt)
     t_ok(not r['success'], [t, 'no success'])

--- a/pypower/t/t_opf_dc_pips_sc.py
+++ b/pypower/t/t_opf_dc_pips_sc.py
@@ -7,7 +7,8 @@
 
 from os.path import dirname, join
 
-from numpy import array, ones, Inf, arange, r_
+from math import inf
+from numpy import array, ones, arange, r_
 
 from scipy.io import loadmat
 from scipy.sparse import csr_matrix as sparse
@@ -98,7 +99,7 @@ def t_opf_dc_pips_sc(quiet=False):
     col = [9, 10, 12, 10, 11, 13]
     ppc['A'] = sparse(([-1, 1, -1, 1, -1, -1], (row, col)), (2, 14))
     ppc['u'] = array([0, 0])
-    ppc['l'] = array([-Inf, -Inf])
+    ppc['l'] = array([-inf, -inf])
     ppc['zl'] = array([0, 0])
 
     ppc['N'] = sparse(([1, 1], ([0, 1], [12, 13])), (2, 14))   ## new z variables only
@@ -120,7 +121,7 @@ def t_opf_dc_pips_sc(quiet=False):
     col = [18, 19, 24, 19, 20, 25]
     ppc['A'] = sparse(([-1, 1, -1, 1, -1, -1], (row, col)), (2, 26))
     ppc['u'] = array([0, 0])
-    ppc['l'] = array([-Inf, -Inf])
+    ppc['l'] = array([-inf, -inf])
     ppc['zl'] = array([0, 0])
 
     ppc['N'] = sparse(([1, 1], ([0, 1], [24, 25])), (2, 26))   ## new z variables only
@@ -140,7 +141,7 @@ def t_opf_dc_pips_sc(quiet=False):
     ## with A and N sized for DC opf
     ppc = loadcase(casefile)
     ppc['A'] = sparse(([1, 1], ([0, 0], [9, 10])), (1, 14))   ## Pg1 + Pg2
-    ppc['u'] = array([Inf])
+    ppc['u'] = array([inf])
     ppc['l'] = array([600])
     r = rundcopf(ppc, ppopt)
     t_ok(not r['success'], [t, 'no success'])

--- a/pypower/t/t_opf_pips.py
+++ b/pypower/t/t_opf_pips.py
@@ -6,8 +6,8 @@
 """
 
 from os.path import dirname, join
-
-from numpy import array, ones, zeros, Inf, r_, ix_, argsort, arange
+from math import inf
+from numpy import array, ones, zeros, r_, ix_, argsort, arange
 
 from scipy.io import loadmat
 from scipy.sparse import spdiags, csr_matrix as sparse
@@ -204,7 +204,7 @@ def t_opf_pips(quiet=False):
     row = [0, 0, 1, 1]
     col = [9, 24, 9, 24]
     A = sparse(([-1, 1, 1, 1], (row, col)), (2, 25))
-    u = array([Inf, Inf])
+    u = array([inf, inf])
     l = array([-1, 1])
 
     N = sparse(([1], ([0], [24])), (1, 25))    ## new z variable only

--- a/pypower/t/t_opf_pips_sc.py
+++ b/pypower/t/t_opf_pips_sc.py
@@ -6,8 +6,8 @@
 """
 
 from os.path import dirname, join
-
-from numpy import array, ones, zeros, Inf, r_, ix_, argsort, arange
+from math import inf
+from numpy import array, ones, zeros, r_, ix_, argsort, arange
 
 from scipy.io import loadmat
 from scipy.sparse import spdiags, csr_matrix as sparse
@@ -204,7 +204,7 @@ def t_opf_pips_sc(quiet=False):
     row = [0, 0, 1, 1]
     col = [9, 24, 9, 24]
     A = sparse(([-1, 1, 1, 1], (row, col)), (2, 25))
-    u = array([Inf, Inf])
+    u = array([inf, inf])
     l = array([-1, 1])
 
     N = sparse(([1], ([0], [24])), (1, 25))    ## new z variable only

--- a/pypower/t/t_pips.py
+++ b/pypower/t/t_pips.py
@@ -5,9 +5,9 @@
 """Tests of PIPS NLP solver.
 """
 
-from math import sqrt
+from math import inf, sqrt
 
-from numpy import zeros, ones, array, eye, prod, dot, ndarray, Inf
+from numpy import zeros, ones, array, eye, prod, dot, ndarray
 
 from scipy.sparse import csr_matrix as sparse
 from scipy.sparse import eye as speye
@@ -225,7 +225,7 @@ def t_pips(quiet=False):
         [0.17, 0.11, 0.10, 0.18]
     ])
     l = array([1,  0.10])
-    u = array([1.0, Inf])
+    u = array([1.0, inf])
     xmin = zeros(4)
     # solution = pips(f_fcn, x0, A, l, u, xmin, opt={'verbose': 2})
     solution = pips(f_fcn, x0, A, l, u, xmin)

--- a/pypower/t/t_qps_pypower.py
+++ b/pypower/t/t_qps_pypower.py
@@ -4,8 +4,8 @@
 
 """Tests of C{qps_pypower} QP solvers.
 """
-
-from numpy import array, zeros, shape, Inf
+from math import inf
+from numpy import array, zeros, shape
 
 from scipy.sparse import csr_matrix as sparse
 
@@ -124,7 +124,7 @@ def t_qps_pypower(quiet=False):
             A = sparse([[   1,       1,       1,       1],
                         [0.17,    0.11,    0.10,    0.18]])
             l = array([1, 0.10])
-            u = array([1, Inf])
+            u = array([1, inf])
             xmin = zeros(4)
             x0 = array([1, 0, 0, 1], float)
             x, f, s, _, lam = qps_pypower(H, c, A, l, u, xmin, None, x0, opt)

--- a/pypower/toggle_dcline.py
+++ b/pypower/toggle_dcline.py
@@ -2,13 +2,14 @@
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file.
 
-from warnings import warn
+from math import inf
 
-from numpy import array, ones, zeros, Inf, r_, c_, concatenate, shape
+from numpy import array, ones, zeros, r_, c_, concatenate, shape
 from numpy import flatnonzero as find
 
 from scipy.sparse import spdiags, hstack, vstack, csr_matrix as sparse
 from scipy.sparse import eye as speye
+from warnings import warn
 
 from pypower import idx_dcline
 from pypower.add_userfcn import add_userfcn
@@ -141,8 +142,8 @@ def userfcn_dcline_ext2int(ppc, args):
     fg = zeros((ndc, ppc['gen'].shape[1]))
     fg[:, MBASE]        = 100
     fg[:, GEN_STATUS]   =  dc[:, c['BR_STATUS']]   ## status (should be all 1's)
-    fg[:, PMIN]         = -Inf
-    fg[:, PMAX]         =  Inf
+    fg[:, PMIN]         = -inf
+    fg[:, PMAX]         =  inf
     tg = fg.copy()
     fg[:, GEN_BUS]      =  dc[:, c['F_BUS']]       ## from bus
     tg[:, GEN_BUS]      =  dc[:, c['T_BUS']]       ## to bus


### PR DESCRIPTION
Pypower calls `Inf` and `NaN` from the Numpy library.
These calls are deprecated and cause Pypower not to function.

This updates these calls to `math.inf` and `math.nan` (added in python3.5)

Merging this means the project is not compatible with python <3.5 anymore. Changes can be made to keep this compatible. (using np.inf instead of math.inf)

If that is preferred I would like to hear and I will change it